### PR TITLE
Remove #runMeFollowing:

### DIFF
--- a/src/MooseIDE-Core/MiAbstractBrowser.class.st
+++ b/src/MooseIDE-Core/MiAbstractBrowser.class.st
@@ -133,14 +133,6 @@ MiAbstractBrowser class >> open [
 		  yourself
 ]
 
-{ #category : #'instance creation' }
-MiAbstractBrowser class >> runMeFollowing: aBus [
-	^ (self on: self newModel)
-		openWithSpec;
-		followBus: aBus;
-		yourself
-]
-
 { #category : #specs }
 MiAbstractBrowser class >> windowSize [
 	^ 500 @ 400

--- a/src/MooseIDE-Core/MiAbstractBrowser.class.st
+++ b/src/MooseIDE-Core/MiAbstractBrowser.class.st
@@ -127,7 +127,10 @@ MiAbstractBrowser class >> newModel [
 { #category : #'instance creation' }
 MiAbstractBrowser class >> open [
 
-	^ self runMeFollowing: self currentApplication defaultBus
+	^ (self on: self newModel)
+		  openWithSpec;
+		  followBus: self currentApplication defaultBus;
+		  yourself
 ]
 
 { #category : #'instance creation' }

--- a/src/MooseIDE-Core/MiBusPresenter.class.st
+++ b/src/MooseIDE-Core/MiBusPresenter.class.st
@@ -28,11 +28,12 @@ MiBusPresenter >> deactivateItem: aBrowser [
 
 { #category : #initialization }
 MiBusPresenter >> initializePresenters [
+
 	super initializePresenters.
 	loggerButton := self newButton
-		iconName: #history;
-		label: 'Open logger';
-		action: [ MiLogBrowser runMeFollowing: model ]
+		                iconName: #history;
+		                label: 'Open logger';
+		                action: [ MiLogBrowser openOnBus: model ]
 ]
 
 { #category : #settings }

--- a/src/MooseIDE-Core/MiLogBrowser.class.st
+++ b/src/MooseIDE-Core/MiLogBrowser.class.st
@@ -41,6 +41,15 @@ MiLogBrowser class >> open [
 		  yourself
 ]
 
+{ #category : #'as yet unclassified' }
+MiLogBrowser class >> openOnBus: aBus [
+
+	^ (self newApplication: self currentApplication)
+		  followBus: aBus;
+		  openWithSpec;
+		  yourself
+]
+
 { #category : #initialization }
 MiLogBrowser class >> title [
 	^ 'Logger'

--- a/src/MooseIDE-Core/MiLogBrowser.class.st
+++ b/src/MooseIDE-Core/MiLogBrowser.class.st
@@ -34,23 +34,11 @@ MiLogBrowser class >> menuCommandOn: aBuilder [
 
 { #category : #'world menu' }
 MiLogBrowser class >> open [
-	<script>
-	| browser |
-	browser := self new
-		initializeBuses: self currentApplication buses;
-		openWithSpec;
-		yourself.
-	^ browser
-]
 
-{ #category : #'world menu' }
-MiLogBrowser class >> runMeFollowing: aBus [
-	| browser |
-	browser := self new
-		initializeBuses: {aBus};
-		openWithSpec;
-		yourself.
-	^ browser
+	<script>
+	^ super open
+		  followBuses: self currentApplication buses;
+		  yourself
 ]
 
 { #category : #initialization }
@@ -81,6 +69,12 @@ MiLogBrowser >> followBus: aBus [
 	self update
 ]
 
+{ #category : #buses }
+MiLogBrowser >> followBuses: aCollectionOfBus [
+
+	aCollectionOfBus do: [ :aBus | self followBus: aBus ]
+]
+
 { #category : #initialization }
 MiLogBrowser >> initializeActionButtons [
 	buttonPropagate := ((MiPropagateCommand forContext: self)
@@ -90,12 +84,6 @@ MiLogBrowser >> initializeActionButtons [
 		name: '';
 		iconName: #smallInspectIt;
 		asButtonPresenter
-]
-
-{ #category : #buses }
-MiLogBrowser >> initializeBuses: someBuses [
-	buses := Set new.
-	someBuses do: [ :bus | super followBus: bus ]
 ]
 
 { #category : #initialization }

--- a/src/MooseIDE-NewTools-Tests/MiNewQueryCreationPresenterTest.class.st
+++ b/src/MooseIDE-NewTools-Tests/MiNewQueryCreationPresenterTest.class.st
@@ -21,7 +21,7 @@ MiNewQueryCreationPresenterTest >> setUp [
 	super setUp.
 
 	helper := FQTestsHelper current.
-	browser := MiNewQueriesBrowser runMeFollowing: self bus.
+	browser := MiNewQueriesBrowser openForTests.
 	browser selectEntity: helper classesAndMethods.
 	parentPresenter := MiQueryBuilderPresenter on: browser.
 

--- a/src/MooseIDE-NewTools-Tests/MiQueryBuilderPresenterTest.class.st
+++ b/src/MooseIDE-NewTools-Tests/MiQueryBuilderPresenterTest.class.st
@@ -29,7 +29,7 @@ MiQueryBuilderPresenterTest >> setUp [
 	| helper |
 	super setUp.
 	helper := FQTestsHelper current.
-	browser := MiNewQueriesBrowser runMeFollowing: self bus.
+	browser := MiNewQueriesBrowser openForTests.
 	browser selectEntity: helper classesAndMethods.
 	presenter := MiQueryBuilderPresenter on: browser
 ]

--- a/src/MooseIDE-Tests/MiAbstractBrowserTest.class.st
+++ b/src/MooseIDE-Tests/MiAbstractBrowserTest.class.st
@@ -81,7 +81,7 @@ MiAbstractBrowserTest >> testCanOpenOnEmptyBus [
 	| newBrowser |
 	self
 		shouldnt: [ 
-			newBrowser := self browserClass runMeFollowing: self bus.
+			newBrowser := self browserClass openForTests.
 			newBrowser window close ]
 		raise: Error
 ]
@@ -93,7 +93,7 @@ MiAbstractBrowserTest >> testCanOpenOnEmptyMooseGroup [
 	self bus globallySelect: MooseGroup new.
 	self
 		shouldnt: [ 
-			newBrowser := self browserClass runMeFollowing: self bus.
+			newBrowser := self browserClass openForTests.
 			newBrowser window close ]
 		raise: Error
 ]
@@ -105,7 +105,7 @@ MiAbstractBrowserTest >> testCanOpenOnEmptyMooseModel [
 	self bus globallySelect: MooseModel new.
 	self
 		shouldnt: [ 
-			newBrowser := self browserClass runMeFollowing: self bus.
+			newBrowser := self browserClass openForTests.
 			newBrowser window close ]
 		raise: Error
 ]
@@ -117,7 +117,7 @@ MiAbstractBrowserTest >> testCanOpenOnMooseEntity [
 	self bus globallySelect: MooseEntity new.
 	self
 		shouldnt: [ 
-			newBrowser := self browserClass runMeFollowing: self bus.
+			newBrowser := self browserClass openForTests.
 			newBrowser window close ]
 		raise: Error
 ]
@@ -129,7 +129,7 @@ MiAbstractBrowserTest >> testCanOpenOnMooseGroup [
 	self bus globallySelect: (MooseGroup with: MooseEntity new).
 	self
 		shouldnt: [ 
-			newBrowser := self browserClass runMeFollowing: self bus.
+			newBrowser := self browserClass openForTests.
 			newBrowser window close ]
 		raise: Error
 ]
@@ -141,7 +141,7 @@ MiAbstractBrowserTest >> testCanOpenOnMooseModel [
 	self bus globallySelect: (MooseModel with: MooseEntity new).
 	self
 		shouldnt: [ 
-			newBrowser := self browserClass runMeFollowing: self bus.
+			newBrowser := self browserClass openForTests.
 			newBrowser window close ]
 		raise: Error
 ]
@@ -153,7 +153,7 @@ MiAbstractBrowserTest >> testCanOpenOnNil [
 	self bus globallySelect: nil.
 	self
 		shouldnt: [ 
-			newBrowser := self browserClass runMeFollowing: self bus.
+			newBrowser := self browserClass openForTests.
 			newBrowser window close ]
 		raise: Error
 ]
@@ -165,7 +165,7 @@ MiAbstractBrowserTest >> testCanOpenOnObject [
 	self bus globallySelect: Object new.
 	self
 		shouldnt: [ 
-			newBrowser := self browserClass runMeFollowing: self bus.
+			newBrowser := self browserClass openForTests.
 			newBrowser window close ]
 		raise: Error
 ]


### PR DESCRIPTION
We do not need this method: browsers open on the default bus.
MiLogBrowser is the only one we may open on a specific bus. It has the method #openOnBus:
This method can be moved up to AbstractBrowser if needed later.