### PR TITLE
Added a MooseInspector command to the playground

### DIFF
--- a/src/MooseIDE-NewTools/KMKeyCombinationChoice.extension.st
+++ b/src/MooseIDE-NewTools/KMKeyCombinationChoice.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #KMKeyCombinationChoice }
+
+{ #category : #'*MooseIDE-NewTools' }
+KMKeyCombinationChoice >> acceptVisitor: aKMShortcutPrinter [
+
+	^ aKMShortcutPrinter visitShortcutCombinationChoice: self
+]
+
+{ #category : #'*MooseIDE-NewTools' }
+KMKeyCombinationChoice >> shortcuts [
+
+	^ shortcuts
+]

--- a/src/MooseIDE-NewTools/KMModifiedKeyCombination.extension.st
+++ b/src/MooseIDE-NewTools/KMModifiedKeyCombination.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #KMModifiedKeyCombination }
+
+{ #category : #'*MooseIDE-NewTools' }
+KMModifiedKeyCombination >> , aShortcut [
+
+	^ KMModifiedKeyCombinationSequence
+		  first: self
+		  next: aShortcut asKeyCombination
+]

--- a/src/MooseIDE-NewTools/KMModifiedKeyCombinationSequence.class.st
+++ b/src/MooseIDE-NewTools/KMModifiedKeyCombinationSequence.class.st
@@ -14,3 +14,15 @@ KMModifiedKeyCombinationSequence >> acceptVisitor: aKMShortcutPrinter [
 
 	^ aKMShortcutPrinter visitModifiedCombinationShortcut: self
 ]
+
+{ #category : #matching }
+KMModifiedKeyCombinationSequence >> matchesCompletely: anEventBuffer [
+
+	anEventBuffer size = shortcuts size ifFalse: [ ^ false ].
+
+	anEventBuffer with: shortcuts do: [ :event :shortcut | 
+		(shortcut matchesCompletely: event asKeyCombination) ifFalse: [ 
+			^ false ] ].
+
+	^ true
+]

--- a/src/MooseIDE-NewTools/KMModifiedKeyCombinationSequence.class.st
+++ b/src/MooseIDE-NewTools/KMModifiedKeyCombinationSequence.class.st
@@ -1,0 +1,16 @@
+"
+I represent a sequence of modified key combinations.
+
+I am only working if all keys are modified.
+"
+Class {
+	#name : #KMModifiedKeyCombinationSequence,
+	#superclass : #KMKeyCombinationSequence,
+	#category : #'MooseIDE-NewTools-Keymapping'
+}
+
+{ #category : #visiting }
+KMModifiedKeyCombinationSequence >> acceptVisitor: aKMShortcutPrinter [
+
+	^ aKMShortcutPrinter visitModifiedCombinationShortcut: self
+]

--- a/src/MooseIDE-NewTools/KMShortcutPrinter.extension.st
+++ b/src/MooseIDE-NewTools/KMShortcutPrinter.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #KMShortcutPrinter }
+
+{ #category : #'*MooseIDE-NewTools' }
+KMShortcutPrinter >> visitModifiedCombinationShortcut: aModifiedCombination [
+
+	^ String streamContents: [ :stream | 
+		  (self shortcutModifiersOf: aModifiedCombination sequence first) 
+			  ifNotEmpty: [ :modifiers | 
+				  modifiers
+					  do: [ :each | stream << each ]
+					  separatedBy: [ stream << '+' ].
+				  stream << '+' ].
+		  aModifiedCombination sequence do: [ :e | 
+			  stream << (self mapSpecialCharacter: e platformCharacter) ] ]
+]
+
+{ #category : #'*MooseIDE-NewTools' }
+KMShortcutPrinter >> visitShortcutCombinationChoice: aShortcutCombinationChoice [
+
+	^ (aShortcutCombinationChoice shortcuts detect: [ :s | 
+		   s platform = Smalltalk os platformFamily or: [ s platform = #all ] ])
+		  shortcut acceptVisitor: self
+]

--- a/src/MooseIDE-NewTools/MiInspectorBrowser.class.st
+++ b/src/MooseIDE-NewTools/MiInspectorBrowser.class.st
@@ -33,6 +33,7 @@ MiInspectorBrowser class >> inspect: anObject forBuses: buses [
 	| newInstance |
 	newInstance := self on: anObject.
 	newInstance openWithSpec.
+	newInstance freeze.
 	buses do: [ :aBus | newInstance followBus: aBus ].
 	^ newInstance
 ]

--- a/src/MooseIDE-NewTools/MiInspectorBrowser.class.st
+++ b/src/MooseIDE-NewTools/MiInspectorBrowser.class.st
@@ -33,7 +33,6 @@ MiInspectorBrowser class >> inspect: anObject forBuses: buses [
 	| newInstance |
 	newInstance := self on: anObject.
 	newInstance openWithSpec.
-	newInstance freeze.
 	buses do: [ :aBus | newInstance followBus: aBus ].
 	^ newInstance
 ]

--- a/src/MooseIDE-NewTools/MiPlaygroundInspectInMooseCommand.class.st
+++ b/src/MooseIDE-NewTools/MiPlaygroundInspectInMooseCommand.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : #MiPlaygroundInspectInMooseCommand,
+	#superclass : #MiPlaygroundCommand,
+	#category : #'MooseIDE-NewTools-Playground'
+}
+
+{ #category : #'accessing - defaults' }
+MiPlaygroundInspectInMooseCommand class >> defaultDescription [
+
+	^ 'Execute selection and inspect the result in a Moose inspector'
+]
+
+{ #category : #'accessing - defaults' }
+MiPlaygroundInspectInMooseCommand class >> defaultName [
+
+	^ 'Inspect in Moose'
+]
+
+{ #category : #default }
+MiPlaygroundInspectInMooseCommand class >> defaultShortcutKey [
+
+	^ ($m command shift , $i command shift) mac
+	  | ($m shift control , $i shift control) win
+	  | ($m shift control , $i shift control) unix
+]
+
+{ #category : #converting }
+MiPlaygroundInspectInMooseCommand >> asSpecCommand [
+
+	^ SpToolCurrentApplicationCommand decorate: (super asSpecCommand
+			   iconName: #smallInspectIt;
+			   shortcutKey: self class defaultShortcutKey;
+			   beDisplayedOnRightSide;
+			   yourself)
+]
+
+{ #category : #executing }
+MiPlaygroundInspectInMooseCommand >> execute [
+
+	| selection |
+	selection := [ self context text selectedTextOrLine ]
+		             on: MessageNotUnderstood
+		             do: [ '' ].
+	"This #on:do: is here to catch a bug in Spec adapters when there is no text to select. 
+	It should be removed when this is fixed, i.e. when inspecting an empty playground does not raise an error anymore."
+
+	selection ifEmpty: [ ^ '' ].
+
+	MiInspectorBrowser inspect: (self context text
+			 evaluate: selection
+			 onCompileError: [ ^ self ]
+			 onError: [ :e | e pass ])
+]

--- a/src/MooseIDE-NewTools/MiPlaygroundModelsPresenter.class.st
+++ b/src/MooseIDE-NewTools/MiPlaygroundModelsPresenter.class.st
@@ -59,7 +59,8 @@ MiPlaygroundModelsPresenter >> initializePresenters [
 	modelsPanel presenter: modelsList.
 
 	previewPanel := (self instantiate: StHeaderPanel) label: 'Preview'.
-	codePreview := self newCode beForScripting beNotEditable.
+	codePreview := self newCode beForScripting beNotEditable
+		               withoutLineNumbers.
 	previewPanel presenter: codePreview.
 
 	self selectFirstModel

--- a/src/MooseIDE-NewTools/MiPlaygroundPagePresenter.class.st
+++ b/src/MooseIDE-NewTools/MiPlaygroundPagePresenter.class.st
@@ -14,11 +14,41 @@ MiPlaygroundPagePresenter >> addModelExpression: anExpression [
 	text insertAndSelectAfterCurrentSelection: anExpression
 ]
 
+{ #category : #private }
+MiPlaygroundPagePresenter >> menuActionsFor: aCodePresenter [
+
+	^ CmCommandGroup forSpec
+		  beRoot;
+		  register: ((CmCommandGroup named: 'Extra') asSpecGroup
+				   beDisplayedAsGroup;
+				   register: (StEvaluateCommand forSpecContext: self);
+				   register:
+					   (MiPlaygroundInspectInMooseCommand forSpecContext: self);
+				   yourself);
+		  register: (aCodePresenter rootCommandsGroup name: 'Code');
+		  register: (aCodePresenter editionCommandsGroup name: 'Edition');
+		  register: ((CmCommandGroup named: 'Playground') asSpecGroup
+				   register: ((CmCommandGroup named: 'Base options') asSpecGroup
+						    beDisplayedAsGroup;
+						    register: (StPlaygroundPublishCommand forSpecContext: self);
+						    register: (StPlaygroundBindingsCommand forSpecContext: self);
+						    register: (StPlaygroundPagesCommand forSpecContext: self);
+						    yourself);
+				   register:
+					   ((CmCommandGroup named: 'Miscelaneous options') asSpecGroup
+						    beDisplayedAsGroup;
+						    register: (StShowLineNumbersCommand forSpecContext: self);
+						    yourself);
+				   yourself);
+		  yourself
+]
+
 { #category : #'instance creation' }
 MiPlaygroundPagePresenter >> toolbarActions [
 
 	^ super toolbarActions
 		  register:
 			  (MiPlaygroundInstalledModelsCommand forSpecContext: self);
+		  register: (MiPlaygroundInspectInMooseCommand forSpecContext: self);
 		  yourself
 ]


### PR DESCRIPTION
This includes extension of the keyboard event mapping that should not be in Moose but in pharo.
This will be proposed to pharo. In the meantime, I add it to MooseIDE so we can have our own shortcuts of the form: 
```Cmd + Shift + M + smthg```.
To open a Moose inspector from the playground, its:
```Cmd + Shift + M + I```