### PR TITLE
Fixed when you create a query that is a child nary or complement query it does not have the correct indentation

### DIFF
--- a/src/MooseIDE-QueriesBrowser-Tests/MiQueriesBrowser.extension.st
+++ b/src/MooseIDE-QueriesBrowser-Tests/MiQueriesBrowser.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #MiQueriesBrowser }
 
 { #category : #'*MooseIDE-QueriesBrowser-Tests' }
+MiQueriesBrowser >> queriesListPresenter [
+	^ queriesListPresenter
+]
+
+{ #category : #'*MooseIDE-QueriesBrowser-Tests' }
 MiQueriesBrowser >> queryCodePresenter [
 
 	self flag: 'Do not use this accessor. This is only for the tests'.

--- a/src/MooseIDE-QueriesBrowser-Tests/MiQueriesBrowserTest.class.st
+++ b/src/MooseIDE-QueriesBrowser-Tests/MiQueriesBrowserTest.class.st
@@ -38,6 +38,30 @@ MiQueriesBrowserTest >> testAddNewNAryQuery [
 		hasSameElements: unionQuery result
 ]
 
+{ #category : #'tests - actions' }
+MiQueriesBrowserTest >> testFollowEntity [
+
+	| previousResult newResult |
+	browser queriesListPresenter addNewFirstLevelQuery.
+	browser queriesListPresenter addNewChildQueryAction:
+		browser queriesListPresenter queryItemsPresenters first query.
+	browser queriesListPresenter addNewFirstLevelQuery.
+	browser queriesListPresenter addNewChildQueryAction:
+		browser queriesListPresenter queryItemsPresenters first query.
+
+	previousResult := (browser queriesListPresenter queryItemsPresenters 
+		                   collect: #query) collect: #result.
+	self bus globallySelect: helper methods.
+	newResult := (browser queriesListPresenter queryItemsPresenters 
+		              collect: #query) collect: #result.
+	"When a new entity is received from the bus we need to keep the same queries but
+	update the result of the queries with the new entity"
+	self assert: previousResult size equals: newResult size.
+	previousResult
+		with: newResult
+		do: [ :a :b | self denyCollection: a hasSameElements: b ]
+]
+
 { #category : #tests }
 MiQueriesBrowserTest >> testInitializePresenters [
 

--- a/src/MooseIDE-QueriesBrowser-Tests/MiQueriesListPresenterTest.class.st
+++ b/src/MooseIDE-QueriesBrowser-Tests/MiQueriesListPresenterTest.class.st
@@ -47,33 +47,42 @@ MiQueriesListPresenterTest >> testAddNewChildQueryAction [
 
 	presenter addNewFirstLevelQuery.
 	presenter addNewChildQueryAction:
-		presenter creationPresenters first query.
-	self assert: presenter creationPresenters size equals: 2.
+		presenter queryItemsPresenters first query.
+	self assert: presenter queryItemsPresenters size equals: 2.
 	self deny:
-		presenter creationPresenters second query parent isRootQuery.
+		presenter queryItemsPresenters second query parent isRootQuery.
+
 	presenter addNewChildQueryAction:
-		presenter creationPresenters second query.
+		presenter queryItemsPresenters second query.
 	presenter addNewChildQueryAction:
-		presenter creationPresenters third query.
+		presenter queryItemsPresenters third query.
 	self
-		assert: presenter creationPresenters last query parentSequence size
-		equals: 5.
-	self assert: presenter creationPresenters last name equals: 'Q4'
+		assert:
+		presenter queryItemsPresenters last query parentSequence size
+		equals: 4.
+	self assert: presenter queryItemsPresenters last name equals: 'Q4'.
+
+	"Check if the child query is added in the right place"
+	presenter addNewChildQueryAction:
+		presenter queryItemsPresenters first query.
+	self assert: presenter queryItemsPresenters second name equals: 'Q5'
 ]
 
 { #category : #tests }
 MiQueriesListPresenterTest >> testAddNewFirstLevelQuery [
 
 	presenter addNewFirstLevelQuery.
-	self assert: presenter creationPresenters size equals: 1.
+	self assert: presenter queryItemsPresenters size equals: 1.
+
 	presenter
 		addNewFirstLevelQuery;
 		addNewFirstLevelQuery;
 		addNewFirstLevelQuery;
 		addNewFirstLevelQuery.
-	self assert: presenter creationPresenters size equals: 5.
-	self assert: presenter creationPresenters last name equals: 'Q5'.
-	presenter creationPresenters do: [ :aPresenter | 
+	self assert: presenter queryItemsPresenters size equals: 5.
+	self assert: presenter queryItemsPresenters last name equals: 'Q5'.
+
+	presenter queryItemsPresenters do: [ :aPresenter | 
 		self assert: aPresenter query parent isRootQuery ]
 ]
 
@@ -82,19 +91,19 @@ MiQueriesListPresenterTest >> testRemoveQueryAction [
 
 	presenter addNewFirstLevelQuery.
 	presenter addNewChildQueryAction:
-		presenter creationPresenters first query.
+		presenter queryItemsPresenters first query.
 
-	presenter removeQueryAction: presenter creationPresenters last.
-	self assert: presenter creationPresenters size equals: 1.
+	presenter removeQueryAction: presenter queryItemsPresenters last.
+	self assert: presenter queryItemsPresenters size equals: 1.
 
 	presenter addNewChildQueryAction:
-		presenter creationPresenters first query.
+		presenter queryItemsPresenters first query.
 	presenter addNewChildQueryAction:
-		presenter creationPresenters second query.
+		presenter queryItemsPresenters second query.
 	presenter addNewChildQueryAction:
-		presenter creationPresenters third query.
-	presenter removeQueryAction: presenter creationPresenters first.
-	self assert: presenter creationPresenters size equals: 0
+		presenter queryItemsPresenters third query.
+	presenter removeQueryAction: presenter queryItemsPresenters first.
+	self assert: presenter queryItemsPresenters size equals: 0
 ]
 
 { #category : #tests }
@@ -102,14 +111,14 @@ MiQueriesListPresenterTest >> testUpdateComponentList [
 
 	self
 		assertCollection: presenter componentList presenters
-		hasSameElements: presenter creationPresenters.
+		hasSameElements: presenter queryItemsPresenters.
 	presenter addNewFirstLevelQuery.
 	self
 		assertCollection: presenter componentList presenters
-		hasSameElements: presenter creationPresenters.
+		hasSameElements: presenter queryItemsPresenters.
 	presenter addNewChildQueryAction:
-		presenter creationPresenters first query.
+		presenter queryItemsPresenters first query.
 	self
 		assertCollection: presenter componentList presenters
-		hasSameElements: presenter creationPresenters
+		hasSameElements: presenter queryItemsPresenters
 ]

--- a/src/MooseIDE-QueriesBrowser-Tests/MiQueryListItemPresenter.extension.st
+++ b/src/MooseIDE-QueriesBrowser-Tests/MiQueryListItemPresenter.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #MiQueryListItemPresenter }
 
 { #category : #'*MooseIDE-QueriesBrowser-Tests' }
+MiQueryListItemPresenter >> parentQuery [
+
+	^ parentQuery
+]
+
+{ #category : #'*MooseIDE-QueriesBrowser-Tests' }
 MiQueryListItemPresenter >> parentQuery: aQuery [
 
 	self flag: 'Do not use this accessor. This is only for the tests'.

--- a/src/MooseIDE-QueriesBrowser-Tests/MiQueryListItemPresenterTest.class.st
+++ b/src/MooseIDE-QueriesBrowser-Tests/MiQueryListItemPresenterTest.class.st
@@ -43,21 +43,51 @@ MiQueryListItemPresenterTest >> tearDown [
 { #category : #tests }
 MiQueryListItemPresenterTest >> testIndentationSpacesPresenters [
 
-	| newQuery lowQuery2 lowQuery1 |
-	newQuery := browser rootQuery.
+	| lowQuery2 lowQuery1 complementQuery naryQuery |
+	self assert: presenter indentationSpacesPresenters size equals: 0.
+
 	lowQuery1 := FQStringQuery new.
-	lowQuery1 beChildOf: newQuery.
+	lowQuery1 beChildOf: browser rootQuery.
+	presenter parentQuery: lowQuery1.
+	self assert: presenter indentationSpacesPresenters size equals: 1.
+
 	lowQuery2 := FQBooleanQuery new.
 	lowQuery2 beChildOf: lowQuery1.
-	self assert: presenter indentationSpacesPresenters size equals: 0.
 	presenter parentQuery: lowQuery2.
-	self assert: presenter indentationSpacesPresenters size equals: 2
+	self assert: presenter indentationSpacesPresenters size equals: 2.
+
+	complementQuery := FQComplementQuery queryToNegate: lowQuery1.
+	presenter parentQuery: complementQuery.
+	self assert: presenter indentationSpacesPresenters size equals: 1.
+
+	naryQuery := FQNAryQuery subqueries: { lowQuery1. lowQuery2 }.
+	presenter parentQuery: naryQuery.
+	self assert: presenter indentationSpacesPresenters size equals: 1
 ]
 
 { #category : #tests }
 MiQueryListItemPresenterTest >> testName [
 
 	self assert: presenter name equals: 'Q1'
+]
+
+{ #category : #tests }
+MiQueryListItemPresenterTest >> testNewQueryForClass [
+
+	"We check that the method doesn't die when calling it from non unary queries"
+
+	presenter newQueryForClass: FQComplementQuery.
+	presenter newQueryForClass: FQNAryQuery.
+
+	self
+		assert: (presenter newQueryForClass: FQBooleanQuery) parent
+		equals: presenter parentQuery.
+	self
+		assert: (presenter newQueryForClass: FQScopeQuery) parent
+		equals: presenter parentQuery.
+	self
+		assert: (presenter newQueryForClass: FQNavigationQuery) parent
+		equals: presenter parentQuery
 ]
 
 { #category : #tests }

--- a/src/MooseIDE-QueriesBrowser/FQAbstractQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQAbstractQuery.extension.st
@@ -7,11 +7,6 @@ FQAbstractQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
 ]
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQAbstractQuery class >> isComplementQuery [
-	^ false
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQAbstractQuery >> isNavigationQuery [
 
 	^ false

--- a/src/MooseIDE-QueriesBrowser/FQNAryQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQNAryQuery.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #FQNAryQuery }
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQNAryQuery class >> isNAryQuery [
-
-	^ true
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQNAryQuery class >> miPresenterClass [ 
 
 	^ MiNAryQueryPresenter

--- a/src/MooseIDE-QueriesBrowser/MiQueriesListPresenter.class.st
+++ b/src/MooseIDE-QueriesBrowser/MiQueriesListPresenter.class.st
@@ -52,12 +52,6 @@ MiQueriesListPresenter >> availableQueryTypes [
 		  each isAvailableForQueriesSize: queryItemsPresenters size ]
 ]
 
-{ #category : #accessing }
-MiQueriesListPresenter >> creationPresenters [
-
-	^ queryItemsPresenters
-]
-
 { #category : #'api - actions' }
 MiQueriesListPresenter >> disableProgressNotification [
 
@@ -178,6 +172,12 @@ MiQueriesListPresenter >> newFirstLevelQueryPresenter [
 MiQueriesListPresenter >> queryChangedUpdate: query [
 
 	parentQueryBrowser selectQuery: query
+]
+
+{ #category : #accessing }
+MiQueriesListPresenter >> queryItemsPresenters [
+
+	^ queryItemsPresenters
 ]
 
 { #category : #actions }

--- a/src/MooseIDE-QueriesBrowser/MiQueryListItemPresenter.class.st
+++ b/src/MooseIDE-QueriesBrowser/MiQueryListItemPresenter.class.st
@@ -45,7 +45,7 @@ MiQueryListItemPresenter class >> on: aQuery owner: aPresenter parentPresenter: 
 { #category : #accessing }
 MiQueryListItemPresenter >> allQueryPresentersExceptSelf [
 
-	^ parentQueryListPresenter creationPresenters reject: [ :q | 
+	^ parentQueryListPresenter queryItemsPresenters reject: [ :q | 
 		  q query = self query ]
 ]
 
@@ -67,7 +67,12 @@ MiQueryListItemPresenter >> indentationSpacesPresenters [
 	"Returns a collection with blank images to show the level of indentation that the query has"
 
 	| indentationPresenters indentationLevel |
-	indentationLevel := parentQuery parentSequence size - 1.
+	"The parent sequence only has sence in the unary queries because they are the
+	only kind of queries that can gave a parent.
+	The other queries don't have a parent so will only return 1"
+	indentationLevel := parentQuery isUnaryQuery
+		                    ifTrue: [ parentQuery parentSequence size ]
+		                    ifFalse: [ 1 ].
 	indentationPresenters := OrderedCollection empty.
 	indentationLevel timesRepeat: [ 
 		indentationPresenters add: (SpImagePresenter new
@@ -156,11 +161,11 @@ MiQueryListItemPresenter >> newQueryForClass: queryClass [
 	(parentQuery children includes: self query) ifTrue: [ 
 		parentQuery removeChild: self query ].
 
-	newQuery := (queryClass isNAryQuery or: [ 
-		             queryClass isComplementQuery ])
-		            ifTrue: [ "Nor the NAry query nor the complement query have a parent " 
-			            queryClass new ]
-		            ifFalse: [ queryClass defaultForParent: parentQuery ].
+	newQuery := queryClass isUnaryQuery
+		            ifTrue: [ "The unary query is the only one that has a parent" 
+			            queryClass defaultForParent: parentQuery ]
+		            ifFalse: [ "Nor the NAry query nor the complement query have a parent " 
+			            queryClass new ].
 	parentQuery addChild: newQuery.
 	^ newQuery
 ]
@@ -175,6 +180,13 @@ MiQueryListItemPresenter >> parentQueryListPresenter [
 MiQueryListItemPresenter >> parentQueryListPresenter: aPresenter [
 
 	parentQueryListPresenter := aPresenter
+]
+
+{ #category : #printing }
+MiQueryListItemPresenter >> printOn: aStream [
+
+	aStream << self name << ' '.
+	self query printOn: aStream
 ]
 
 { #category : #accessing }

--- a/src/MooseIDE-QueriesBrowser/Object.extension.st
+++ b/src/MooseIDE-QueriesBrowser/Object.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #Object }
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
-Object >> isNAryQuery [
-
-	^ false
-]


### PR DESCRIPTION
Fixed: when you create a query that is a child of a nary or complement query it does not have the correct indentation