### PR TITLE
MiSourceTextBrowser highlighting

### DIFF
--- a/src/MooseIDE-Famix/MiSourceTextBrowser.class.st
+++ b/src/MooseIDE-Famix/MiSourceTextBrowser.class.st
@@ -69,7 +69,7 @@ MiSourceTextBrowser >> canFollowEntity: anObject [
 MiSourceTextBrowser >> followEntity: anEntity [
 
 	model selected: anEntity.
-	self text: (model sourceText ifEmpty: [ self noSourceCodeMessageFor: anEntity ]).
+	self text: model formatedSource.
 	self updateWindowTitleWith: anEntity name
 ]
 
@@ -86,14 +86,7 @@ MiSourceTextBrowser >> miSelectedItem [
 ]
 
 { #category : #actions }
-MiSourceTextBrowser >> noSourceCodeMessageFor: anEntity [
-
-	^ 'There is no source code to show for {1}' format: { anEntity name }
-]
-
-{ #category : #actions }
 MiSourceTextBrowser >> text: aText [
-
 	sourceText text: aText
 ]
 

--- a/src/MooseIDE-Famix/MiSourceTextBrowserModel.class.st
+++ b/src/MooseIDE-Famix/MiSourceTextBrowserModel.class.st
@@ -7,6 +7,26 @@ Class {
 	#category : #'MooseIDE-Famix-SourceText'
 }
 
+{ #category : #'as yet unclassified' }
+MiSourceTextBrowserModel >> formatedSource [
+	| entityAnchor entityText|
+	entityText := self sourceText ifEmpty: [ ^self noSourceCodeMessageFor: selected ].
+	entityAnchor := selected sourceAnchor.
+	^entityText
+
+	
+]
+
+{ #category : #actions }
+MiSourceTextBrowserModel >> noSourceCodeMessageFor: anEntity [
+	| text |
+	text := ('There is no source code to show for {1}'
+		format: { anEntity name })
+		asText.
+	text addAttribute: (TextColor red) from: 1 to: 35.
+	^text
+]
+
 { #category : #accessing }
 MiSourceTextBrowserModel >> selected [
 	^ selected


### PR DESCRIPTION
first step of a possibly long journey:
- Moved some behavior from MiSourceTextBrowser to its model
- when there is no source code to display, the error message is in red