### PR TITLE
Fix #362 clear queries in QueryBrowser

### DIFF
--- a/src/MooseIDE-QueriesBrowser/MiQueriesListPresenter.class.st
+++ b/src/MooseIDE-QueriesBrowser/MiQueriesListPresenter.class.st
@@ -221,8 +221,9 @@ MiQueriesListPresenter >> queryItemsPresenters [
 MiQueriesListPresenter >> reinitializeQueryPresenters [
 
 	queryCounter := 1.
+	self announcer subscriptions reset.
 	queryItemsPresenters := OrderedCollection new.
-	self updateComponentList
+	componentListPresenter presenters: queryItemsPresenters
 ]
 
 { #category : #actions }


### PR DESCRIPTION
Fix #362 : Reset subscribtions to QueriesListChangedAnnouncement when removing queries.
