### PR TITLE
Open Source text in external editor using Windows

### DIFF
--- a/src/MooseIDE-Famix/MiExternalEditorOpenner.class.st
+++ b/src/MooseIDE-Famix/MiExternalEditorOpenner.class.st
@@ -1,0 +1,79 @@
+Class {
+	#name : #MiExternalEditorOpenner,
+	#superclass : #OSPlatformVisitor,
+	#instVars : [
+		'command',
+		'pathString'
+	],
+	#category : #'MooseIDE-Famix-SourceText'
+}
+
+{ #category : #'as yet unclassified' }
+MiExternalEditorOpenner class >> open: aPathString using: editorCommand [
+	self new
+		pathString: aPathString;
+		command: editorCommand;
+		visit
+]
+
+{ #category : #accessing }
+MiExternalEditorOpenner >> command [
+
+	^ command
+]
+
+{ #category : #accessing }
+MiExternalEditorOpenner >> command: anObject [
+
+	command := anObject
+]
+
+{ #category : #'as yet unclassified' }
+MiExternalEditorOpenner >> open: aPathString using: editorCommand [
+	self new
+]
+
+{ #category : #accessing }
+MiExternalEditorOpenner >> pathString [
+
+	^ pathString
+]
+
+{ #category : #accessing }
+MiExternalEditorOpenner >> pathString: anObject [
+
+	pathString := anObject
+]
+
+{ #category : #'private - ffi' }
+MiExternalEditorOpenner >> privShellExecute: lpOperation file: lpFile parameters: lpParameters directory: lpDirectory show: nShowCmd [
+	^ self ffiCall: #( 
+			FFIConstantHandle ShellExecuteA(
+     				0,
+     				char* lpOperation,
+         			char* lpFile,
+     				char* lpParameters,
+     				char* lpDirectory,
+        			int nShowCmd)) module: #shell32
+]
+
+{ #category : #'private - ffi' }
+MiExternalEditorOpenner >> visitMacOS: aPlatform [
+	LibC runCommand: ('{1} "{2}"' format: {command . pathString})
+]
+
+{ #category : #'private - ffi' }
+MiExternalEditorOpenner >> visitUnix: aPlatform [
+	LibC runCommand: ('{1} "{2}"' format: {command . pathString})
+]
+
+{ #category : #'private - ffi' }
+MiExternalEditorOpenner >> visitWindows: aPlatform [
+
+	self
+		privShellExecute: ''
+		file: command
+		parameters: ('"{1}"' format: { pathString })
+		directory: ''
+		show: 0 "SW_SHOW"
+]

--- a/src/MooseIDE-Famix/MiSourceTextExternalEditorEmacs.class.st
+++ b/src/MooseIDE-Famix/MiSourceTextExternalEditorEmacs.class.st
@@ -11,5 +11,5 @@ MiSourceTextExternalEditorEmacs class >> editorName [
 
 { #category : #'file support' }
 MiSourceTextExternalEditorEmacs >> openFile: aFileReference [
-	LibC uniqueInstance runCommand: 'emacs ' , aFileReference fullName 
+	MiExternalEditorOpenner open: aFileReference fullName using: 'emacs'
 ]

--- a/src/MooseIDE-Famix/MiSourceTextExternalEditorVSCode.class.st
+++ b/src/MooseIDE-Famix/MiSourceTextExternalEditorVSCode.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #MiSourceTextExternalEditorVSCode,
+	#superclass : #MiSourceTextFileExternalEditor,
+	#category : #'MooseIDE-Famix-SourceText'
+}
+
+{ #category : #'as yet unclassified' }
+MiSourceTextExternalEditorVSCode class >> editorName [
+	^'VS Code'
+]
+
+{ #category : #'file support' }
+MiSourceTextExternalEditorVSCode >> openFile: aFileReference [
+
+	MiExternalEditorOpenner open: aFileReference fullName using: 'code'
+]

--- a/src/MooseIDE-Famix/MiSourceTextExternalEditorVSCodium.class.st
+++ b/src/MooseIDE-Famix/MiSourceTextExternalEditorVSCodium.class.st
@@ -11,5 +11,6 @@ MiSourceTextExternalEditorVSCodium class >> editorName [
 
 { #category : #'file support' }
 MiSourceTextExternalEditorVSCodium >> openFile: aFileReference [
-	LibC uniqueInstance runCommand: 'codium ' , aFileReference fullName 
+
+	MiExternalEditorOpenner open: aFileReference fullName using: 'codium'
 ]


### PR DESCRIPTION
fix #435 

- I extended the OSPlatform visitor to perform the Windows way to open emacs/codium/and so one if we are using Windows, and the Linux or OSX way in the other cases

This is the approach used in the NativeBrowserOpenVisitor