### PR TITLE
Add MooseIDE-Tagging-Tests to baseline

### DIFF
--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -68,6 +68,8 @@ BaselineOfMooseIDE >> definePackages: spec [
 		package: 'MooseIDE-Tagging'
 		with: [ 
 			spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' ) ];
+		package: 'MooseIDE-Tagging-Tests'
+		with: [ spec requires: #( 'MooseIDE-Tagging' ) ];
 		package: 'MooseIDE-Telescope'
 		with: [ 
 			spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' ) ];


### PR DESCRIPTION
This PR will fail on `MiTagManagementPageTest>>#testShowIntentTagsOnlyInTagList`.

This failure is due to this merge: 6ee59b4677fd3e206a5be0b42dfc14be1ad92873
The tests of MooseIDE-Tagging-Tests were not loaded because they were absent from the baseline.

This PR fixes the baseline. It is now expecting for another commit to fix the test. 

@NicolasAnquetil I tag you because you made the change and you may be in the best place to know how to fix this. If not, please tell me and I'll check.