### PR TITLE
Fix Moose Inspector navigation pane when inspecting a MooseModel

### DIFF
--- a/src/MooseIDE-NewTools/MiModelNavigationBrowser.class.st
+++ b/src/MooseIDE-NewTools/MiModelNavigationBrowser.class.st
@@ -8,5 +8,5 @@ Class {
 MiModelNavigationBrowser >> itemsFor: anEntity [
 
 	^ anEntity navigationItemsFromPragmas
-	  , anEntity navigationItemsFromAttributes
+	  , anEntity navigationItemsFromMetamodel
 ]

--- a/src/MooseIDE-NewTools/MooseModel.extension.st
+++ b/src/MooseIDE-NewTools/MooseModel.extension.st
@@ -20,3 +20,16 @@ MooseModel >> mooseInterestingEntity [
 	self entityStorage forRuntime.
 	^ self
 ]
+
+{ #category : #'*MooseIDE-NewTools' }
+MooseModel >> navigationItemsFromMetamodel [
+
+	| classes |
+
+	^ (self metamodel classes reject: [ :a | 
+		            a implementingClass isTrait ])
+		           collect: [ :metaClass | 
+			           metaClass implementingClass inspectorToString
+			           -> (self allWithSubTypesOf: metaClass implementingClass) ]
+		           thenReject: [ :a | a value isEmpty ]
+]

--- a/src/MooseIDE-NewTools/MooseObject.extension.st
+++ b/src/MooseIDE-NewTools/MooseObject.extension.st
@@ -33,29 +33,6 @@ MooseObject >> miPropertiesInspectorExtension [
 ]
 
 { #category : #'*MooseIDE-NewTools' }
-MooseObject >> navigationItemsFromAttributes [
-
-	| entity assocs attrs |
-	"returns associations in form name->object for navigation entities obtained from
-	the the meta-model attributes of the item"
-	entity := self mooseInterestingEntity.
-	attrs := entity allDeclaredProperties reject: [ :attribute | 
-		         attribute type isPrimitive ].
-	assocs := attrs collect: [ :anAttribute | 
-		          anAttribute name
-		          -> (entity perform: anAttribute compiledMethod selector) ].
-
-	"filter out nils and empty collections, sort"
-	^ (assocs reject: [ :association | 
-		   association value isNil or: [ 
-			   association value isCollection and: [ association value isEmpty ] ] ]) 
-		  sorted:
-			  [ :a | 
-			  a key formatForNavigationPresentation asLowercase asString ]
-				  ascending
-]
-
-{ #category : #'*MooseIDE-NewTools' }
 MooseObject >> navigationItemsFromPragmas [
 
 	| pragmaValueAssociations |


### PR DESCRIPTION
This PR aims to fix a problem with the Navigation panel when inspecting a MooseModel that does not show all the possible entities.

It may duplicate the navigation entries when we have a FamixModel with classes, methods, *etc.* but it also allows us to use model with other kind of entities (for custom model such as Casino)


fix #407
fix #582