### PR TITLE
655 clicking on a method name in the duplication browser causes exception

### DIFF
--- a/src/MooseIDE-Duplication/MiDuplicationBrowserModel.class.st
+++ b/src/MooseIDE-Duplication/MiDuplicationBrowserModel.class.st
@@ -115,7 +115,7 @@ MiDuplicationBrowserModel >> hierarchyOfReplicatedFragment: aCollectionOfFragmen
 { #category : #api }
 MiDuplicationBrowserModel >> highlightEntity: entitiesToHighlight [
 
-	browser selectedFragments:
+	self selectedFragments:
 		(entitiesToHighlight flatCollectAsSet: [ :entity | 
 			 entity replicas collect: #replicatedFragment ])
 ]

--- a/src/MooseIDE-Duplication/MiDuplicationBrowserModel.class.st
+++ b/src/MooseIDE-Duplication/MiDuplicationBrowserModel.class.st
@@ -115,7 +115,7 @@ MiDuplicationBrowserModel >> hierarchyOfReplicatedFragment: aCollectionOfFragmen
 { #category : #api }
 MiDuplicationBrowserModel >> highlightEntity: entitiesToHighlight [
 
-	self selectedFragments:
+	browser selectFragments:
 		(entitiesToHighlight flatCollectAsSet: [ :entity | 
 			 entity replicas collect: #replicatedFragment ])
 ]

--- a/src/MooseIDE-Tests/MiDuplicationBrowserModelTest.class.st
+++ b/src/MooseIDE-Tests/MiDuplicationBrowserModelTest.class.st
@@ -182,7 +182,7 @@ MiDuplicationBrowserModelTest >> testHierarchyOfReplicatedFragment [
 MiDuplicationBrowserModelTest >> testHighlightEntity [
 
 	| selectedFragments |
-	(model browser stub selectedFragments: Any) will: [ 
+	(model browser stub selectFragments: Any) will: [ 
 		:receivedFragments | selectedFragments := receivedFragments ].
 
 	self assert: selectedFragments isNil.

--- a/src/MooseIDE-Tests/MiDuplicationBrowserTest.class.st
+++ b/src/MooseIDE-Tests/MiDuplicationBrowserTest.class.st
@@ -127,6 +127,17 @@ MiDuplicationBrowserTest >> testResetReplicas [
 	self assertEmpty: browser panCodes pages
 ]
 
+{ #category : #tests }
+MiDuplicationBrowserTest >> testSelectEntity [
+	"issue https://github.com/moosetechnology/MooseIDE/issues/655"
+
+	browser model entities: { 
+		(self method: 'method1').
+		(self method: 'method2') } asMooseGroup.
+
+	self shouldnt: (browser lstEntities selectIndex: 1) raise: Error.
+]
+
 { #category : #'tests - opening' }
 MiDuplicationBrowserTest >> testSettingsAction [
 


### PR DESCRIPTION
fix #655