### PR TITLE
MiExportBrowser: evaluating name using displayStringOn:

### DIFF
--- a/src/MooseIDE-Export/MiExportBrowser.class.st
+++ b/src/MooseIDE-Export/MiExportBrowser.class.st
@@ -169,7 +169,9 @@ MiExportBrowser >> commonPropertiesIn: aMooseGroup [
 MiExportBrowser >> defaultTableColumns [
 
 	^ { 
-		  ((SpStringTableColumn title: 'Name' evaluated: #name)
+		  ((SpStringTableColumn 
+				title: 'Name' 
+				evaluated: [ :entity | String streamContents: [ :s | entity displayStringOn: s ] ])
 			   beSortable;
 			   yourself).
 		  ((SpStringTableColumn


### PR DESCRIPTION
Changed evaluated name to display the name shown in an inspector for every entity, including associations.
Before the changes, an association's name was displayed as "noname", so the exporter was useless for those entities.
Using displayStringOn: fixes the problem. 
The test MooseObjectTest>>testAllMooseDisplayOn also seems to suggest that this change would work on every entity.