### PR TITLE
Correct filter stub implementation in Models Browser.

### DIFF
--- a/src/MooseIDE-Core/MiAbstractBrowser.class.st
+++ b/src/MooseIDE-Core/MiAbstractBrowser.class.st
@@ -428,6 +428,12 @@ MiAbstractBrowser >> miSelectedItem [
 	^ (MiNoSelectedElementToPropagateException browser: self) signal
 ]
 
+{ #category : #asserting }
+MiAbstractBrowser >> miTransformedSelectedItem [
+	"Not used if shouldPropagateFilter returns false."
+	^ self miSelectedItem
+]
+
 { #category : #accessing }
 MiAbstractBrowser >> model [
 	^ model
@@ -484,6 +490,12 @@ MiAbstractBrowser >> settings [
 	"not used if #hasSettings is false"
 
 	self subclassResponsibility 
+]
+
+{ #category : #asserting }
+MiAbstractBrowser >> shouldPropagateTransformedSelectedItem [
+
+	^ false
 ]
 
 { #category : #actions }

--- a/src/MooseIDE-Core/MiPropagateCommand.class.st
+++ b/src/MooseIDE-Core/MiPropagateCommand.class.st
@@ -52,13 +52,16 @@ MiPropagateCommand >> initialize [
 
 { #category : #testing }
 MiPropagateCommand >> propagate [
+
 	| selectedItem |
-	selectedItem := [ self context miSelectedItem ]
-		on: MiNoSelectedElementToPropagateException
-		do: [ :exception | 
-			exception signal.
-			^ self ].
-	selectedItem isMooseObject
-		ifFalse: [ ^ self ].
+	selectedItem := [ 
+	                self context shouldPropagateTransformedSelectedItem
+		                ifFalse: [ self context miSelectedItem ]
+		                ifTrue: [ self context miTransformedSelectedItem ] ]
+		                on: MiNoSelectedElementToPropagateException
+		                do: [ :exception | 
+			                exception signal.
+			                ^ self ].
+	selectedItem isMooseObject ifFalse: [ ^ self ].
 	self context buses do: [ :bus | bus globallySelect: selectedItem ]
 ]

--- a/src/MooseIDE-Meta/MiModelRootBrowser.class.st
+++ b/src/MooseIDE-Meta/MiModelRootBrowser.class.st
@@ -160,8 +160,14 @@ modelFilteringList items: aList
 
 { #category : #accessing }
 MiModelRootBrowser >> miSelectedItem [
+ 	
+	^ model selected
+]
 
-	^model selected
+{ #category : #accessing }
+MiModelRootBrowser >> miTransformedSelectedItem [
+
+	^ (model selected reject: [ :each | each isStub ]) asMooseGroup
 ]
 
 { #category : #'accessing - tests' }
@@ -188,6 +194,12 @@ MiModelRootBrowser >> settings [
 { #category : #'accessing - tests' }
 MiModelRootBrowser >> settingsItem [
 	^ model settings
+]
+
+{ #category : #asserting }
+MiModelRootBrowser >> shouldPropagateTransformedSelectedItem [
+
+	^ model filterStubsSetting
 ]
 
 { #category : #actions }

--- a/src/MooseIDE-Meta/MiModelRootBrowserModel.class.st
+++ b/src/MooseIDE-Meta/MiModelRootBrowserModel.class.st
@@ -51,6 +51,12 @@ MiModelRootBrowserModel >> canPropagate [
 	^ selected isMooseObject
 ]
 
+{ #category : #accessing }
+MiModelRootBrowserModel >> filterStubsSetting [
+
+ ^ settings getItemValue: #filterStubsSetting
+]
+
 { #category : #updating }
 MiModelRootBrowserModel >> getAllModelRootBrowsers [
 	^browser application allBrowsers: MiModelRootBrowser
@@ -102,11 +108,7 @@ MiModelRootBrowserModel >> rawSelectedMooseModel [
 { #category : #accessing }
 MiModelRootBrowserModel >> selected [
 
-	^ (settings getItemValue: #filterStubsSetting)
-		  ifTrue: [ 
-			  selected ifNotNil: [ :selectedModel | 
-				  (selectedModel reject: [ :each | each isStub ]) asMooseGroup ] ]
-		  ifFalse: [ selected ]
+	^ selected
 ]
 
 { #category : #accessing }

--- a/src/MooseIDE-Tests/MiModelRootBrowserTest.class.st
+++ b/src/MooseIDE-Tests/MiModelRootBrowserTest.class.st
@@ -43,8 +43,8 @@ MiModelRootBrowserTest >> testActivateActionButtons [
 
 { #category : #tests }
 MiModelRootBrowserTest >> testFilterStubsSettingsWithoutStub [
-
 	| newModel |
+	self flag: 'to be relevant this test should call the propagate method of MiPropagateCommand. Using miTransformedSelectedItem and miSelectedItem hack this requirements'.
 	self assert: browser miSelectedItem isNil.
 
 	newModel := FamixStModel new.
@@ -55,8 +55,8 @@ MiModelRootBrowserTest >> testFilterStubsSettingsWithoutStub [
 	MooseModel root add: newModel.
 	browser updateForNewModel: newModel.
 
-	self assert: browser miSelectedItem size equals: 1.
-	self assert: browser miSelectedItem anyOne name equals: 'Class2'.
+	self assert: browser miTransformedSelectedItem  size equals: 1.
+	self assert: browser miTransformedSelectedItem anyOne name equals: 'Class2'.
 
 	browser settingsItem setItem: #filterStubsSetting value: false.
 	browser updateForNewModel: newModel.
@@ -82,6 +82,7 @@ MiModelRootBrowserTest >> testMiSelectedItem [
 MiModelRootBrowserTest >> testMiSelectedItemWithoutStub [
 
 	| newModel |
+	self flag: 'to be relevant this test should call the propagate method of MiPropagateCommand. Using miTransformedSelectedItem and miSelectedItem hack this requirements'.
 	self assert: browser miSelectedItem isNil.
 
 	newModel := FamixStModel new.
@@ -93,8 +94,8 @@ MiModelRootBrowserTest >> testMiSelectedItemWithoutStub [
 	MooseModel root add: newModel.
 	browser updateForNewModel: newModel.
 
-	self assert: browser miSelectedItem size equals: 1.
-	self assert: browser miSelectedItem anyOne name equals: 'Class2'
+	self assert: browser miTransformedSelectedItem  size equals: 1.
+	self assert: browser miTransformedSelectedItem anyOne name equals: 'Class2'
 	
 
 	


### PR DESCRIPTION
More generaly, now a browser can propagate a transformed version of the selected item.
Fix #672
Fix #641
