### PR TITLE
The critics browser should accept every kind of moose entity

### DIFF
--- a/src/Famix-CriticBrowser-Entities/FamixCBRootContext.class.st
+++ b/src/Famix-CriticBrowser-Entities/FamixCBRootContext.class.st
@@ -30,7 +30,7 @@ FamixCBRootContext >> removeSelfFromTree [
 
 { #category : #running }
 FamixCBRootContext >> runOn: aCollection [
-	entities := aCollection sort: [ :a :b | a name < b name ]
+	entities := aCollection sort: [ :a :b | a mooseName < b mooseName ]
 
 	
 ]

--- a/src/MooseIDE-CriticBrowser/MiCriticBrowser.class.st
+++ b/src/MooseIDE-CriticBrowser/MiCriticBrowser.class.st
@@ -443,7 +443,7 @@ MiCriticBrowser >> selectedRules [
 	(rules selectedItem) 
 		ifNotNil: [
 			self updateResultList: (model violationsOf: rules selectedItem).
-			self updateEntitiesList: (model contextOf: rules selectedItem)]
+			self updateEntitiesList: (model contextOf: rules selectedItem) asMooseGroup]
 		ifNil: [ 
 			self updateResultList: model getAllViolations.
 			self updateEntitiesList: model entities ]

--- a/src/MooseIDE-CriticBrowser/MiCriticBrowserModel.class.st
+++ b/src/MooseIDE-CriticBrowser/MiCriticBrowserModel.class.st
@@ -144,11 +144,11 @@ MiCriticBrowserModel >> runCondition: aCondition [
 
 { #category : #accessing }
 MiCriticBrowserModel >> setEntities: aMooseObject [
+
 	entities := aMooseObject isCollection
-		ifTrue: [ (aMooseObject allUsing: FamixTNamedEntity) ]
-		ifFalse: [ ({aMooseObject} asMooseGroup) allUsing: FamixTNamedEntity ].
+		            ifTrue: [ aMooseObject ]
+		            ifFalse: [ { aMooseObject } asMooseGroup ].
 	self resetResults
-	
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
In my opinion, the critics browser should accept any kind of Moose Entity and not only the users of FamixTNamedEntity.

Or we cannot use it with Fast, Casino, and other kinds of metamodel that can appear (SQL, and so on).

I have updated FamixCBRootContext  to use mooseName instead of name (mooseName is the correct keyword to retrieve name of entities)
and the MiCriticBrowserModel setEntities to accept every kind of entity.
Maybe we can change it to something like allSatisfy: isMooseEntity?

Also, I have fixed a strange bug with collection 