### PR TITLE
Optimize add violation

### DIFF
--- a/src/Famix-CriticBrowser-Entities/FamixCBCondition.class.st
+++ b/src/Famix-CriticBrowser-Entities/FamixCBCondition.class.st
@@ -87,9 +87,10 @@ FamixCBCondition >> runDownTree: aCollection [
 
 { #category : #running }
 FamixCBCondition >> runOn: aCollection [
-	
-	((self query runOnCollection: aCollection) do: 
-		[ :each | self addViolation: (FamixCBViolation condition: self violatedBy: each) ]).
+
+	(self query runOnCollection: aCollection) do: [ :each | 
+		"doing condition: self = self AddViolation: (FamixCBViolation) but it is a lot more performant"
+		FamixCBViolation condition: self violatedBy: each ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Famix-CriticBrowser-Entities/FamixCBCondition.class.st
+++ b/src/Famix-CriticBrowser-Entities/FamixCBCondition.class.st
@@ -44,7 +44,7 @@ FamixCBCondition >> addViolation: anObject [
 
 { #category : #'as yet unclassified' }
 FamixCBCondition >> putViolationsInto: aDictionary [
-	aDictionary at: self put: violations asMooseGroup specialize
+	aDictionary at: self put: violations asMooseSpecializedGroup
 ]
 
 { #category : #accessing }
@@ -89,8 +89,7 @@ FamixCBCondition >> runDownTree: aCollection [
 FamixCBCondition >> runOn: aCollection [
 
 	(self query runOnCollection: aCollection) do: [ :each | 
-		"doing condition: self = self AddViolation: (FamixCBViolation) but it is a lot more performant"
-		FamixCBViolation condition: self violatedBy: each ]
+		self addViolation: (FamixCBViolation new violatingEntity: each) ]
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
Before addViolation was used two times:

In:

```st
FamixCBCondition >> runOn: 
    ((self query runOnCollection: aCollection) do: 
		[ :each | self addViolation: (FamixCBViolation condition: self violatedBy: each) ]).
```

Violation is added by: `addViolation:` and using the setter `condition: self`. Moreover, `addViolation` is better than `condition:` because it checks that the violation is not present in the condition yet.

So, I change the method for:

````st
self addViolation: (FamixCBViolation new violatingEntity: each) ]
```

So, it keeps the same behavior as before, and it is more optimized.


> I have also ran all the tests manually because CI is dead...
