### PR TITLE
[ExportBrowser] addQueryColumn should retrun the newly created column

### DIFF
--- a/src/MooseIDE-Export/MiExportModel.class.st
+++ b/src/MooseIDE-Export/MiExportModel.class.st
@@ -48,7 +48,8 @@ MiExportModel >> addColumnForQuery: aBlock withName: queryName [
 			              query: aBlock;
 			              name: queryName;
 			              yourself).
-	self columnAdded: newColumn
+	self columnAdded: newColumn.
+	^ newColumn
 ]
 
 { #category : #events }

--- a/src/MooseIDE-Tests/MiExportModelTest.class.st
+++ b/src/MooseIDE-Tests/MiExportModelTest.class.st
@@ -1,0 +1,26 @@
+"
+A MiExportModelTest is a test class for testing the behavior of MiExportModel
+"
+Class {
+	#name : #MiExportModelTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'model'
+	],
+	#category : #'MooseIDE-Tests-Browsers'
+}
+
+{ #category : #running }
+MiExportModelTest >> setUp [
+	super setUp.
+
+	model := MiExportModel new.
+]
+
+{ #category : #running }
+MiExportModelTest >> testaddColumnForQuerywithNameReturnAColumn [
+
+	| returned |
+	returned := model addColumnForQuery: [ :param |  ] withName: #aName.
+	self assert: returned class equals: MiExportQueryColumnModel
+]


### PR DESCRIPTION
Add the return statement and a test to ensure keeping this feature in the future