### PR TITLE
Update FamixCriticsBrowser to last version

### DIFF
--- a/src/Famix-CriticBrowser-Entities/FamixCBModel.class.st
+++ b/src/Famix-CriticBrowser-Entities/FamixCBModel.class.st
@@ -16,3 +16,9 @@ FamixCBModel class >> annotation [
 	<package: #'Famix-CriticBrowser-Entities'>
 	<generated>
 ]
+
+{ #category : #testing }
+FamixCBModel class >> canBeImportedFromFile [
+	<generated>
+	^true
+]


### PR DESCRIPTION
The metamodel has been updated in https://github.com/moosetechnology/Famix/pull/507
This PR aims to regenerate the MooseIDE metamodels (only one is concerned) to follow Famix's improvement and restore Moose image building 
