### PR TITLE
711 models browser utilities are disabled when stubs are filtered out

### DIFF
--- a/src/MooseIDE-Core/MiModelUtilityCommand.class.st
+++ b/src/MooseIDE-Core/MiModelUtilityCommand.class.st
@@ -38,5 +38,6 @@ MiModelUtilityCommand >> canBeExecuted [
 
 { #category : #accessing }
 MiModelUtilityCommand >> model [
-	^ self context miSelectedItem
+
+	^ self context miSelectedModel
 ]

--- a/src/MooseIDE-Meta/MiModelRootBrowser.class.st
+++ b/src/MooseIDE-Meta/MiModelRootBrowser.class.st
@@ -181,6 +181,13 @@ MiModelRootBrowser >> miSelectedItem [
 	^model selected
 ]
 
+{ #category : #accessing }
+MiModelRootBrowser >> miSelectedModel [
+	"similar to #miSelectedItem but ignore the setting #filterStubsSetting"
+
+	^model selectedModel
+]
+
 { #category : #'accessing - tests' }
 MiModelRootBrowser >> modelFilteringList [
 	^ modelFilteringList

--- a/src/MooseIDE-Meta/MiModelRootBrowserModel.class.st
+++ b/src/MooseIDE-Meta/MiModelRootBrowserModel.class.st
@@ -104,15 +104,21 @@ MiModelRootBrowserModel >> selected [
 
 	^ (settings getItemValue: #filterStubsSetting)
 		  ifTrue: [ 
-			  selected ifNotNil: [ :selectedModel | 
+			  self selectedModel ifNotNil: [ :selectedModel | 
 				  (selectedModel reject: [ :each | each isStub ]) asMooseGroup ] ]
-		  ifFalse: [ selected ]
+		  ifFalse: [ self selectedModel ]
 ]
 
 { #category : #accessing }
 MiModelRootBrowserModel >> selected: anObject [
 	selected := anObject.
 	browser updateToolbar
+]
+
+{ #category : #accessing }
+MiModelRootBrowserModel >> selectedModel [
+
+	^selected
 ]
 
 { #category : #'accessing - tests' }


### PR DESCRIPTION
Implemented my own solution to fix 711
LABSARI solution in another PR was not very good (recreating a new model each time we need one (like right click on the model to get a contextual menu)