### PR TITLE
CriticBrowser optimization - reduce number of collection copy in model code

### DIFF
--- a/src/MooseIDE-CriticBrowser-Tests/MiCriticBrowserTest.class.st
+++ b/src/MooseIDE-CriticBrowser-Tests/MiCriticBrowserTest.class.st
@@ -230,7 +230,7 @@ MiCriticBrowserTest >> testUpdateEntitiesList [
 
 { #category : #test }
 MiCriticBrowserTest >> testUpdateResultList [
-	browser updateResultList: { FamixCBViolation condition: stubRule violatedBy: stubEntity } asMooseGroup specialize.
+	browser updateResultList: { FamixCBViolation condition: stubRule violatedBy: stubEntity } asMooseSpecializedGroup.
 	self assert: (browser rulesResult roots flatten size) equals: 1.
 	
 	browser updateResultList: FamixCBViolationGroup new.

--- a/src/MooseIDE-CriticBrowser/MiCriticBrowserModel.class.st
+++ b/src/MooseIDE-CriticBrowser/MiCriticBrowserModel.class.st
@@ -31,7 +31,7 @@ MiCriticBrowserModel >> addChildToRootContext: aRuleComponent [
 
 { #category : #adding }
 MiCriticBrowserModel >> addViolationsFor: aCondition [
-	violations at: aCondition put: aCondition violations asMooseGroup specialize
+	violations at: aCondition put: aCondition violations asMooseSpecializedGroup
 ]
 
 { #category : #'as yet unclassified' }
@@ -163,9 +163,9 @@ MiCriticBrowserModel >> violationsOf: aRuleComponent [
 	^ (aRuleComponent class inheritsFromOrEqualTo: FamixCBContext)
 		ifTrue: 
 			[ | group |
-			group := MooseGroup new.
+			group := OrderedCollection new.
 			aRuleComponent children do: [ :child | group addAll: (self violationsOf: child) ].
-			group specialize
+			group asMooseSpecializedGroup
 			]
 		ifFalse:
 			[ 
@@ -178,6 +178,6 @@ MiCriticBrowserModel >> violationsOfCollection: aCollection [
 "returns violations for a given set of rules"
 	| result |
 	result := FamixCBViolationGroup new.
-	aCollection do: [ :condition | result := result , (self violationsOf: condition) ].
+	aCollection do: [ :condition | result addAll: (self violationsOf: condition) ].
 	^ result 
 ]


### PR DESCRIPTION
This PR reduces the number of collection copy to optimize the Critic browser