### PR TITLE
Fix #641

### DIFF
--- a/src/MooseIDE-Core/MiAbstractBrowser.class.st
+++ b/src/MooseIDE-Core/MiAbstractBrowser.class.st
@@ -39,7 +39,8 @@ Class {
 	#instVars : [
 		'buses',
 		'receivingMode',
-		'specModel'
+		'specModel',
+		'inspector'
 	],
 	#category : #'MooseIDE-Core-Browser'
 }
@@ -435,6 +436,7 @@ MiAbstractBrowser >> initialize [
 
 	super initialize.
 	self setDefaultReceivingMode.
+	inspector := MiInspectorBrowser.
 	buses := Set new
 ]
 
@@ -451,6 +453,18 @@ MiAbstractBrowser >> initializeWindow: aMiWindowPresenter [
 	aMiWindowPresenter initialExtent: self class windowSize
 ]
 
+{ #category : #'private - for tests' }
+MiAbstractBrowser >> inspector [
+
+	^ inspector
+]
+
+{ #category : #accessing }
+MiAbstractBrowser >> inspector: anObject [
+
+	inspector := anObject
+]
+
 { #category : #testing }
 MiAbstractBrowser >> isMiBrowser [
 	^ true
@@ -459,6 +473,12 @@ MiAbstractBrowser >> isMiBrowser [
 { #category : #testing }
 MiAbstractBrowser >> isModelImporter [
 	^self class isModelImporter
+]
+
+{ #category : #'as yet unclassified' }
+MiAbstractBrowser >> miInspect [
+
+	self inspector inspect: self miSelectedItem forBuses: buses
 ]
 
 { #category : #accessing }

--- a/src/MooseIDE-Core/MiInspectCommand.class.st
+++ b/src/MooseIDE-Core/MiInspectCommand.class.st
@@ -33,11 +33,9 @@ MiInspectCommand >> canBeExecuted [
 { #category : #executing }
 MiInspectCommand >> execute [
 
-	| selectedItem |
-	selectedItem := [ self context miSelectedItem ]
-		                on: MiNoSelectedElementToPropagateException
-		                do: [ :exception | 
-			                exception signal.
-			                ^ self ].
-	MiInspectorBrowser inspect: selectedItem forBuses: self context buses
+	[ self context miInspect ]
+		on: MiNoSelectedElementToPropagateException
+		do: [ :exception | 
+			exception signal.
+			^ self ]
 ]

--- a/src/MooseIDE-Meta/MiModelRootBrowser.class.st
+++ b/src/MooseIDE-Meta/MiModelRootBrowser.class.st
@@ -197,6 +197,12 @@ MiModelRootBrowser >> listOfMooseModels: aList [
 	
 ]
 
+{ #category : #'as yet unclassified' }
+MiModelRootBrowser >> miInspect [
+
+	self inspector inspect: self miSelectedModel forBuses: buses
+]
+
 { #category : #accessing }
 MiModelRootBrowser >> miSelectedItem [
 

--- a/src/MooseIDE-Tests/MiModelRootBrowserTest.class.st
+++ b/src/MooseIDE-Tests/MiModelRootBrowserTest.class.st
@@ -113,6 +113,43 @@ MiModelRootBrowserTest >> testHandleDropFileImportsModel [
 ]
 
 { #category : #tests }
+MiModelRootBrowserTest >> testMiInspectCommand [
+
+	| inspector result newModel |
+	newModel := self newModel: 'aModel'.
+	newModel add: FamixStClass new.
+	browser updateForNewModel: newModel.
+
+	inspector := Mock named: 'inspector'.
+	(inspector stub inspect: Any forBuses: Any) will: [ :object :buses | 
+		result := object ].
+
+	browser inspector: inspector.
+	browser miInspect.
+
+	self assert: result equals: newModel
+]
+
+{ #category : #tests }
+MiModelRootBrowserTest >> testMiInspectCommandWithoutStubFilter [
+
+	| inspector result newModel |
+	newModel := self newModel: 'aModel'.
+	newModel add: FamixStClass new.
+
+	browser updateForNewModel: newModel.
+	browser model settings setItem: #filterStubsSetting value: false.
+	inspector := Mock named: 'inspector'.
+	(inspector stub inspect: Any forBuses: Any) will: [ :object :buses | 
+		result := object ].
+
+	browser inspector: inspector.
+	browser miInspect.
+
+	self assert: result equals: newModel
+]
+
+{ #category : #tests }
 MiModelRootBrowserTest >> testMiSelectedItem [
 
 	| newModel |


### PR DESCRIPTION
Move inspect action in MiAbstractBrowser. Now a browser can define what to inspect. We did it for Models browser.