### PR TITLE
Fixing 914

### DIFF
--- a/src/MooseIDE-NewTools/MiInspectorBrowser.class.st
+++ b/src/MooseIDE-NewTools/MiInspectorBrowser.class.st
@@ -32,7 +32,7 @@ MiInspectorBrowser class >> inspect: anObject [
 
 	^ self
 		  inspect: anObject
-		  forBuses: self currentApplication defaultBus asCollection
+		  forBuses: (OrderedCollection with: self currentApplication defaultBus asCollection)
 ]
 
 { #category : #api }


### PR DESCRIPTION
`asCollection` is calling `asOrderedCollection` which is the deprecated method. To fix this issue, we applied changes with @uNouss only for the main method, to avoid changing `asCollection` that is called in many many methods.  The changes are applied as recommended by the deprecation comments of `asOrderedCollection` method: `(OrderedCollection with: @receiver)`