### PR TITLE
Update package organizer API

### DIFF
--- a/src/MooseIDE-CoUsageMap/MiCoUsageMapModel.class.st
+++ b/src/MooseIDE-CoUsageMap/MiCoUsageMapModel.class.st
@@ -273,12 +273,9 @@ MiCoUsageMapModel >> openSettings [
 
 	| settingBrowser |
 	settingBrowser := SettingBrowser new.
-	settingBrowser changePackageSet: (OrderedCollection with:
-			 (RPackage organizer packageNamed:
-				  MiCoUsageMapSettings package name)).
+	settingBrowser changePackageSet: (OrderedCollection with: (self packageOrganizer packageNamed: MiCoUsageMapSettings package name)).
 	settingsWindow := settingBrowser open.
-	settingsWindow position:
-		self currentWorld extent - settingsWindow extent // 2.
+	settingsWindow position: self currentWorld extent - settingsWindow extent // 2.
 	settingBrowser expandAll.
 
 	self currentWorld announcer when: WindowClosed do: [ :annoucement |

--- a/src/MooseIDE-Meta/MiImportModelFromSmalltalkDialog.class.st
+++ b/src/MooseIDE-Meta/MiImportModelFromSmalltalkDialog.class.st
@@ -207,7 +207,7 @@ MiImportModelFromSmalltalkDialog >> initializePresenters [
 	modelNameField := self newTextInput text: 'MooseModel'.
 
 	packagesSelector := self instantiate: SpChooserPresenter.
-	packagesSelector sourceItems: RPackage organizer packageNames.
+	packagesSelector sourceItems: self packageOrganizer packageNames.
 
 	advancedSettingsButton := self newToggleButton
 		label: 'Advanced settings';


### PR DESCRIPTION
In Pharo 12 the way to access the package organizer changed. I added the new way to PharoBackwardCompatibility so that we can use the new way in any Moose image. This change is to use it