### PR TITLE
Speed up Models browser

### DIFF
--- a/src/MooseIDE-Core/MiAbstractBrowser.class.st
+++ b/src/MooseIDE-Core/MiAbstractBrowser.class.st
@@ -399,10 +399,9 @@ MiAbstractBrowser >> canHighlight [
 MiAbstractBrowser >> canPropagate [
 
 	| entity |
-
+	"Ideally we should use miSelectedItemToPropagate but this would make the models browser really slow since it would copy the whole model and reject the stubs each time I'm called. So we do not care about checking the stubs here by calling #miSelectedItem.."
 	entity := self miSelectedItem.
-	^ entity isMooseObject and: [ 
-		  entity asMooseGroup isNotEmpty or: [ entity isMooseModel ] ]
+	^ entity isMooseObject and: [ entity isMooseModel or: [ entity asMooseGroup isNotEmpty ] ]
 ]
 
 { #category : #testing }
@@ -521,6 +520,13 @@ MiAbstractBrowser >> isModelImporter [
 MiAbstractBrowser >> miSelectedItem [
 
 	^ (MiNoSelectedElementToPropagateException browser: self) signal
+]
+
+{ #category : #accessing }
+MiAbstractBrowser >> miSelectedItemToPropagate [
+	"Hook to be able to add some filters in the model browser."
+
+	^ self miSelectedItem
 ]
 
 { #category : #accessing }

--- a/src/MooseIDE-Core/MiModelUtilityCommand.class.st
+++ b/src/MooseIDE-Core/MiModelUtilityCommand.class.st
@@ -39,5 +39,5 @@ MiModelUtilityCommand >> canBeExecuted [
 { #category : #accessing }
 MiModelUtilityCommand >> model [
 
-	^ self context miSelectedModel
+	^ self context miSelectedItem
 ]

--- a/src/MooseIDE-Core/MiPropagateCommand.class.st
+++ b/src/MooseIDE-Core/MiPropagateCommand.class.st
@@ -59,7 +59,7 @@ MiPropagateCommand >> initialize [
 { #category : #testing }
 MiPropagateCommand >> propagate [
 	| selectedItem |
-	selectedItem := [ self context miSelectedItem ]
+	selectedItem := [ self context miSelectedItemToPropagate ]
 		on: MiNoSelectedElementToPropagateException
 		do: [ :exception | 
 			exception signal.

--- a/src/MooseIDE-Meta/MiModelsBrowser.class.st
+++ b/src/MooseIDE-Meta/MiModelsBrowser.class.st
@@ -188,15 +188,13 @@ MiModelsBrowser >> listOfMooseModels: aList [
 { #category : #accessing }
 MiModelsBrowser >> miSelectedItem [
 
-	^ specModel selectedModel
+	^ specModel selected
 ]
 
 { #category : #accessing }
-MiModelsBrowser >> miSelectedModel [
+MiModelsBrowser >> miSelectedItemToPropagate [
 
-	"similar to #miSelectedItem but ignore the setting #filterStubsSetting"
-
-	^ specModel selected
+	^ specModel selectedModel
 ]
 
 { #category : #'accessing - tests' }

--- a/src/MooseIDE-Meta/MiModelsBrowserModel.class.st
+++ b/src/MooseIDE-Meta/MiModelsBrowserModel.class.st
@@ -119,16 +119,20 @@ MiModelsBrowserModel >> selected: anObject [
 { #category : #accessing }
 MiModelsBrowserModel >> selectedModel [
 
-	^ (settings getItemValue: #filterStubsSetting)
-		  ifTrue: [ 
-			  self selected ifNotNil: [ :selectedModel | 
-				  (selectedModel reject: [ :each | each isStub ]) asMooseGroup ] ]
+	^ self shouldFilterStubs
+		  ifTrue: [ self selected ifNotNil: [ :selectedModel | (selectedModel reject: [ :each | each isStub ]) asMooseGroup ] ]
 		  ifFalse: [ self selected ]
 ]
 
 { #category : #'accessing - tests' }
 MiModelsBrowserModel >> settings [
 	^ settings
+]
+
+{ #category : #accessing }
+MiModelsBrowserModel >> shouldFilterStubs [
+
+	^ settings getItemValue: #filterStubsSetting
 ]
 
 { #category : #updating }

--- a/src/MooseIDE-NewTools/MiModelsBrowser.extension.st
+++ b/src/MooseIDE-NewTools/MiModelsBrowser.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #MiModelsBrowser }
-
-{ #category : #'*MooseIDE-NewTools' }
-MiModelsBrowser >> miInspect [
-
-	self inspector inspect: self miSelectedModel forBuses: buses
-]

--- a/src/MooseIDE-Tests/MiModelsBrowserTest.class.st
+++ b/src/MooseIDE-Tests/MiModelsBrowserTest.class.st
@@ -76,22 +76,24 @@ MiModelsBrowserTest >> testCanTagEntities [
 MiModelsBrowserTest >> testFilterStubsSettingsWithoutStub [
 
 	| newModel |
-	self assert: browser miSelectedItem isNil.
+	self assert: browser miSelectedItemToPropagate isNil.
 
 	newModel := self newModel: 'aModel'.
-	newModel addAll: { 
-			(FamixStClass named: 'Class1') isStub: true; yourself.
-			(FamixStClass named: 'Class2') isStub: false; yourself}.
+	newModel addAll: {
+			((FamixStClass named: 'Class1')
+				 isStub: true;
+				 yourself).
+			((FamixStClass named: 'Class2')
+				 isStub: false;
+				 yourself) }.
 	browser updateForNewModel: newModel.
 
-	self assert: browser miSelectedItem size equals: 1.
-	self assert: browser miSelectedItem anyOne name equals: 'Class2'.
+	self assert: browser miSelectedItemToPropagate size equals: 1.
+	self assert: browser miSelectedItemToPropagate anyOne name equals: 'Class2'.
 
 	browser settingsItem setItem: #filterStubsSetting value: false.
 	browser updateForNewModel: newModel.
-	self assert: browser miSelectedItem size equals: 2.
-
-	
+	self assert: browser miSelectedItemToPropagate size equals: 2
 ]
 
 { #category : #tests }
@@ -166,7 +168,7 @@ MiModelsBrowserTest >> testMiSelectedItem [
 MiModelsBrowserTest >> testMiSelectedItemWithoutStub [
 
 	| newModel |
-	self assert: browser miSelectedItem isNil.
+	self assert: browser miSelectedItemToPropagate isNil.
 
 	newModel := self newModel: 'aModel'.
 	newModel addAll: { 
@@ -174,8 +176,8 @@ MiModelsBrowserTest >> testMiSelectedItemWithoutStub [
 			(FamixStClass named: 'Class2') isStub: false; yourself}.
 	browser updateForNewModel: newModel.
 
-	self assert: browser miSelectedItem size equals: 1.
-	self assert: browser miSelectedItem anyOne name equals: 'Class2'
+	self assert: browser miSelectedItemToPropagate size equals: 1.
+	self assert: browser miSelectedItemToPropagate anyOne name equals: 'Class2'
 	
 
 	


### PR DESCRIPTION
The model browser can be really slow if we have big models in the image. This is due to the fact that propagating is filtering the stubs. But this means that #canPropagate it always filtering the stubs without using any cache (it would be hard to cache this). 

I propose to not filter in #canPropagate because we should almost never have a model without non stub entities and this will make the tools way smoother. We'll filter only on the propagate.

Fixes #976