### PR TITLE
Make tag browser twice faster

### DIFF
--- a/src/MooseIDE-Tagging/MiTagManagementPage.class.st
+++ b/src/MooseIDE-Tagging/MiTagManagementPage.class.st
@@ -167,10 +167,9 @@ MiTagManagementPage >> preparePageFor: aTag [
 { #category : #refreshing }
 MiTagManagementPage >> refresh [
 
-	self refreshDescriptionPage.
 	self refreshTagList.
 	self refreshCategoryList.
-	descriptionPage refresh.
+	self refreshDescriptionPage
 ]
 
 { #category : #refreshing }


### PR DESCRIPTION
This is a first step at speeding up the tag browser. We were refreshing twice the description page of the tag browser making it really slow. Now I propose to refresh it only once.

With an image of 1.7Go this makes the opening time go from 21sec to 9sec.