### PR TITLE
Speed up opening of tag browser on big models

### DIFF
--- a/src/MooseIDE-Tagging/MiTagBrowser.class.st
+++ b/src/MooseIDE-Tagging/MiTagBrowser.class.st
@@ -58,6 +58,7 @@ MiTagBrowser class >> newModel [
 
 { #category : #'instance creation' }
 MiTagBrowser class >> open [
+
 	<script>
 	^ super open
 ]

--- a/src/MooseIDE-Tagging/MiTagExtentPage.class.st
+++ b/src/MooseIDE-Tagging/MiTagExtentPage.class.st
@@ -18,6 +18,13 @@ Class {
 	#category : #'MooseIDE-Tagging-Browser'
 }
 
+{ #category : #accessing }
+MiTagExtentPage class >> maxNumberOfEntitiesToSort [
+	"If we have a 'small' number of untagged entities we will sort them to be user friendly. But if we have a lot of them, this will just take too much time. In that case we will just not sort them. Here I'm defining the limit, with a magic number for a start, maybe this could be a setting in the future but I'm not sure it brings much value."
+
+	^ 10000
+]
+
 { #category : #action }
 MiTagExtentPage >> add [
 
@@ -136,20 +143,18 @@ MiTagExtentPage >> onBrowserPageRedisplay [
 MiTagExtentPage >> refresh [
 
 	super refresh.
-	self refreshEntitiesList. 
+	self refreshEntitiesList.
 	self refreshTaggedEntitiesList.
 	self update
-	
 ]
 
 { #category : #refreshing }
 MiTagExtentPage >> refreshEntitiesList [
 
-	| sortedEntities untaggedEntities |
-	untaggedEntities := self model entities asCollection
-	                    \ self taggedEntities asCollection.
-	sortedEntities := untaggedEntities sort: [ :a :b | a name < b name ].
-	incomingEntitiesFilteringList items: sortedEntities
+	| untaggedEntities |
+	untaggedEntities := self model entities asCollection \ self taggedEntities asCollection.
+	untaggedEntities size < self class maxNumberOfEntitiesToSort ifTrue: [ untaggedEntities sort: [ :a :b | a name < b name ] ].
+	incomingEntitiesFilteringList items: untaggedEntities
 ]
 
 { #category : #refreshing }

--- a/src/MooseIDE-Tagging/MiTagManagementPage.class.st
+++ b/src/MooseIDE-Tagging/MiTagManagementPage.class.st
@@ -137,7 +137,6 @@ MiTagManagementPage >> initializePresenters [
 	addTagButton := self newButton icon: (Smalltalk iconNamed: #smallAdd).
 	addTagButton action: [ self owner openTagCreationForm ].
 
-
 	self initializeLayout
 ]
 
@@ -180,8 +179,9 @@ MiTagManagementPage >> refreshCategoryList [
 
 { #category : #refreshing }
 MiTagManagementPage >> refreshDescriptionPage [
+	"No need to refresh if this is hidden."
 
-	descriptionPage refresh
+	descriptionPage isVisible ifTrue: [ descriptionPage refresh ]
 ]
 
 { #category : #refreshing }
@@ -251,7 +251,7 @@ MiTagManagementPage >> setTagTo: aTag [
 	self preparePageFor: aTag.
 	descriptionPage setTag: aTag.
 	descriptionPage show.
-	descriptionPage refresh.
+	self refreshDescriptionPage.
 	self update
 ]
 


### PR DESCRIPTION
Do not sort untagged entities if there are more than 10000

Fixes #979