### PR TITLE
Speed up a few browsers

### DIFF
--- a/src/MooseIDE-Core/MiAbstractVisualizationBrowser.class.st
+++ b/src/MooseIDE-Core/MiAbstractVisualizationBrowser.class.st
@@ -75,7 +75,7 @@ MiAbstractVisualizationBrowser >> miSelectedItem [
 
 	^ mainPresenter miSelectedItem ifEmpty: [
 		  specModel ifNil: [ ^ #(  ) ].
-		  specModel entities mooseInterestingEntity ]
+		  specModel entities ]
 ]
 
 { #category : #actions }

--- a/src/MooseIDE-Famix/MiUMLBrowser.class.st
+++ b/src/MooseIDE-Famix/MiUMLBrowser.class.st
@@ -118,7 +118,7 @@ MiUMLBrowser >> initializePresenters [
 { #category : #accessing }
 MiUMLBrowser >> miSelectedItem [
 
-	^ (specModel selected ifNil: [ specModel entities ]) mooseInterestingEntity
+	^ specModel selected ifNil: [ specModel entities ]
 ]
 
 { #category : #accessing }

--- a/src/MooseIDE-NewTools/MiAbstractBrowser.extension.st
+++ b/src/MooseIDE-NewTools/MiAbstractBrowser.extension.st
@@ -2,6 +2,7 @@ Extension { #name : #MiAbstractBrowser }
 
 { #category : #'*MooseIDE-NewTools' }
 MiAbstractBrowser >> miInspect [
+	"For the inspector we try to have a specialized moose entity to provide the most useful information."
 
-	self inspector inspect: self miSelectedItem forBuses: buses
+	self inspector inspect: self miSelectedItem mooseInterestingEntity forBuses: buses
 ]

--- a/src/MooseIDE-QueriesBrowser/MiQueriesBrowser.class.st
+++ b/src/MooseIDE-QueriesBrowser/MiQueriesBrowser.class.st
@@ -195,12 +195,7 @@ MiQueriesBrowser >> itemsFor: aClass [
 { #category : #accessing }
 MiQueriesBrowser >> miSelectedItem [
 
-	| selected |
-	selected := queryResultTreePresenter miSelectedItem
-		            ifEmpty: [ selectedQuery result ]
-		            ifNotEmpty: [ :items | items ].
-
-	^ selected mooseInterestingEntity
+	^ queryResultTreePresenter miSelectedItem ifEmpty: [ selectedQuery result ] ifNotEmpty: [ :items | items ]
 ]
 
 { #category : #accessing }

--- a/src/MooseIDE-Tests/MiUMLBrowserTest.class.st
+++ b/src/MooseIDE-Tests/MiUMLBrowserTest.class.st
@@ -33,5 +33,6 @@ MiUMLBrowserTest >> testMiSelectedItem [
 	entityToSelect := FamixStClass named: 'TestClass'.
 	browser followEntity: entityToSelect.
 
-	self assert: browser miSelectedItem equals: entityToSelect
+	self assert: browser miSelectedItem size equals: 1.
+	self assert: browser miSelectedItem anyOne equals: entityToSelect
 ]

--- a/src/MooseIDE-Visualization/MiAbstractVisualization.class.st
+++ b/src/MooseIDE-Visualization/MiAbstractVisualization.class.st
@@ -53,8 +53,7 @@ MiAbstractVisualization >> initialize [
 { #category : #accessing }
 MiAbstractVisualization >> miSelectedItem [
 
-	^ (self canvas selectedShapes collect: [ :shape |
-		   self modelForShape: shape ]) mooseInterestingEntity
+	^ self canvas selectedShapes collect: [ :shape | self modelForShape: shape ]
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
Some browsers and calling #mooseInterestingEntity in their #miSelectedItem method. This will either return a moose entity if a collection has 1 element or return a moose specialized group.

I think this is not a good idea because this means we will generate moose groups each time we ask for the selected entity, which can happen often. For exemple to know if we should display the propagate or the inspect button in each browsers, at each refresh. 

In an image with small models this can be ignored, but when you start to have big models it becomes really long to always create moose groups of thousands of elements. 

I propose to remove the call to this method and instead to use it only in one place: The MiInspect command. This is, I think, the only place where it is interesting to have a specialized group (and I'm not even sure).

I have an image of 1.7Gb and opening the query browser went from 3sec to 300ms with this change. And this is the same for each action causing a refresh of the browser.