### PR TITLE
Rename classes with abbreviations in the names

### DIFF
--- a/src/MooseIDE-Dependency/MiDependencyStructuralMatrixBrowser.class.st
+++ b/src/MooseIDE-Dependency/MiDependencyStructuralMatrixBrowser.class.st
@@ -33,7 +33,7 @@ Controls:
 - R to clear all searches
 "
 Class {
-	#name : #MiDSMBrowser,
+	#name : #MiDependencyStructuralMatrixBrowser,
 	#superclass : #MiAbstractBrowser,
 	#instVars : [
 		'mainPresenter'
@@ -42,95 +42,95 @@ Class {
 }
 
 { #category : #'world menu' }
-MiDSMBrowser class >> menuCommandOn: aBuilder [
+MiDependencyStructuralMatrixBrowser class >> menuCommandOn: aBuilder [
 
 	<worldMenu>
 	^ self buildMenuItemIn: aBuilder
 ]
 
 { #category : #'world menu' }
-MiDSMBrowser class >> menuIconName [
+MiDependencyStructuralMatrixBrowser class >> menuIconName [
 
 	^ #mooseTree
 ]
 
 { #category : #'world menu' }
-MiDSMBrowser class >> menuItem [
+MiDependencyStructuralMatrixBrowser class >> menuItem [
 
 	^ #DSMVisualisationBrowser
 ]
 
 { #category : #'world menu' }
-MiDSMBrowser class >> menuLabel [
+MiDependencyStructuralMatrixBrowser class >> menuLabel [
 
 	^ 'Dependency Structural Matrix'
 ]
 
 { #category : #'world menu' }
-MiDSMBrowser class >> menuPriority [
+MiDependencyStructuralMatrixBrowser class >> menuPriority [
 
 	^ self menuVisualizationToolsPriority + 4
 ]
 
 { #category : #'instance creation' }
-MiDSMBrowser class >> newModel [
-	^MiDSMBrowserModel new
+MiDependencyStructuralMatrixBrowser class >> newModel [
+	^MiDependencyStructuralMatrixBrowserModel new
 ]
 
 { #category : #'instance creation' }
-MiDSMBrowser class >> open [
+MiDependencyStructuralMatrixBrowser class >> open [
 
 	<script>
 	^ super open
 ]
 
 { #category : #specs }
-MiDSMBrowser class >> title [
+MiDependencyStructuralMatrixBrowser class >> title [
 
 	^ 'Dependency Structural Matrix'
 ]
 
 { #category : #api }
-MiDSMBrowser >> buildDSM [
+MiDependencyStructuralMatrixBrowser >> buildDSM [
 	mainPresenter run
 ]
 
 { #category : #testing }
-MiDSMBrowser >> canFollowEntity: anObject [
+MiDependencyStructuralMatrixBrowser >> canFollowEntity: anObject [
 
 	^specModel canFollowEntity: anObject
 ]
 
 { #category : #testing }
-MiDSMBrowser >> canTagEntities [ 
+MiDependencyStructuralMatrixBrowser >> canTagEntities [ 
 	^false
 ]
 
 { #category : #accessing }
-MiDSMBrowser >> diagram [
+MiDependencyStructuralMatrixBrowser >> diagram [
 
 	^ mainPresenter
 ]
 
 { #category : #actions }
-MiDSMBrowser >> followEntity: anEntity [
+MiDependencyStructuralMatrixBrowser >> followEntity: anEntity [
 	specModel followEntity: anEntity
 ]
 
 { #category : #initialization }
-MiDSMBrowser >> initializePresenters [
+MiDependencyStructuralMatrixBrowser >> initializePresenters [
 
-	mainPresenter := self instantiate: MiDSMVisualization.
+	mainPresenter := self instantiate: MiDependencyStructuralMatrixVisualization.
 	mainPresenter viewModel: specModel
 ]
 
 { #category : #accessing }
-MiDSMBrowser >> miSelectedItem [
+MiDependencyStructuralMatrixBrowser >> miSelectedItem [
 
 	^specModel selectedEntities
 ]
 
 { #category : #api }
-MiDSMBrowser >> showSCC: aCollection [
+MiDependencyStructuralMatrixBrowser >> showSCC: aCollection [
 	mainPresenter showSCC: aCollection 
 ]

--- a/src/MooseIDE-Dependency/MiDependencyStructuralMatrixBrowserModel.class.st
+++ b/src/MooseIDE-Dependency/MiDependencyStructuralMatrixBrowserModel.class.st
@@ -2,7 +2,7 @@
 A model for the MiDSMBrowser, contains the entities to display, computes the dependencies and the colors to show the cells of the DSM matrix
 "
 Class {
-	#name : #MiDSMBrowserModel,
+	#name : #MiDependencyStructuralMatrixBrowserModel,
 	#superclass : #MiAbstractModel,
 	#instVars : [
 		'graph',
@@ -14,7 +14,7 @@ Class {
 }
 
 { #category : #buildGraph }
-MiDSMBrowserModel >> buildGraphEdges [
+MiDependencyStructuralMatrixBrowserModel >> buildGraphEdges [
 	"We choose to say that there is a relation from line to column if line depends on column"
 	| entities |
 	entities := self entities.
@@ -31,7 +31,7 @@ MiDSMBrowserModel >> buildGraphEdges [
 ]
 
 { #category : #buildGraph }
-MiDSMBrowserModel >> buildGraphNodes: aCollection [
+MiDependencyStructuralMatrixBrowserModel >> buildGraphNodes: aCollection [
 
 	graph nodes: (aCollection asMooseGroup select: [ :e | 
 			 e usesFamixTrait: TEntityMetaLevelDependency ]).
@@ -40,7 +40,7 @@ MiDSMBrowserModel >> buildGraphNodes: aCollection [
 ]
 
 { #category : #testing }
-MiDSMBrowserModel >> canFollowEntity: anObject [
+MiDependencyStructuralMatrixBrowserModel >> canFollowEntity: anObject [
 
 	^ anObject isCollection and: [ 
 		  anObject allSatisfy: [ :a | 
@@ -48,7 +48,7 @@ MiDSMBrowserModel >> canFollowEntity: anObject [
 ]
 
 { #category : #api }
-MiDSMBrowserModel >> colorForTuple: tuple [
+MiDependencyStructuralMatrixBrowserModel >> colorForTuple: tuple [
 
 	(self isDiagonal: tuple) ifTrue: [ ^self diagonalColor ].
 	(self isDependency: tuple) ifFalse: [ ^self defaultColor ].
@@ -58,46 +58,46 @@ MiDSMBrowserModel >> colorForTuple: tuple [
 ]
 
 { #category : #buildGraph }
-MiDSMBrowserModel >> computeSCCs [
+MiDependencyStructuralMatrixBrowserModel >> computeSCCs [
 	"run tarjan"
 	graph run
 ]
 
 { #category : #settings }
-MiDSMBrowserModel >> defaultColor [
+MiDependencyStructuralMatrixBrowserModel >> defaultColor [
 
 	^ nodeColors at: #defaultCell
 ]
 
 { #category : #settings }
-MiDSMBrowserModel >> dependencyColor [
+MiDependencyStructuralMatrixBrowserModel >> dependencyColor [
 	"a 'nice' blue for cells with dependency"
 	^ nodeColors at: #dependency
 ]
 
 { #category : #settings }
-MiDSMBrowserModel >> diagonalColor [
+MiDependencyStructuralMatrixBrowserModel >> diagonalColor [
 
 	^nodeColors at: #diagonalCell
 ]
 
 { #category : #api }
-MiDSMBrowserModel >> displayValueForNode: aNode [
+MiDependencyStructuralMatrixBrowserModel >> displayValueForNode: aNode [
 	^aNode model name
 ]
 
 { #category : #api }
-MiDSMBrowserModel >> displayValueForTuple: tuple [
+MiDependencyStructuralMatrixBrowserModel >> displayValueForTuple: tuple [
 	^(self displayValueForNode: tuple key), ' -> ' , (self displayValueForNode: tuple value)
 ]
 
 { #category : #accessing }
-MiDSMBrowserModel >> entities [
+MiDependencyStructuralMatrixBrowserModel >> entities [
 	^graph nodes collect: #model
 ]
 
 { #category : #actions }
-MiDSMBrowserModel >> followEntity: aCollection [
+MiDependencyStructuralMatrixBrowserModel >> followEntity: aCollection [
 
 	self newGraph.
 	self buildGraphNodes: aCollection.
@@ -108,14 +108,14 @@ MiDSMBrowserModel >> followEntity: aCollection [
 ]
 
 { #category : #initialization }
-MiDSMBrowserModel >> initialize [ 
+MiDependencyStructuralMatrixBrowserModel >> initialize [ 
 	super initialize.
 	self initializeColors.
 	self newGraph.
 ]
 
 { #category : #initialization }
-MiDSMBrowserModel >> initializeColors [
+MiDependencyStructuralMatrixBrowserModel >> initializeColors [
 	nodeColors := Dictionary new: 5.
 
 	nodeColors at: #diagonalCell put: Color veryLightGray.
@@ -129,36 +129,36 @@ MiDSMBrowserModel >> initializeColors [
 ]
 
 { #category : #testing }
-MiDSMBrowserModel >> isCycle: tuple [
+MiDependencyStructuralMatrixBrowserModel >> isCycle: tuple [
 
 	^tuple key cycleNodes includes: tuple value
 ]
 
 { #category : #testing }
-MiDSMBrowserModel >> isDependency: tuple [
+MiDependencyStructuralMatrixBrowserModel >> isDependency: tuple [
 
 	^tuple key adjacentNodes includes: tuple value
 ]
 
 { #category : #testing }
-MiDSMBrowserModel >> isDiagonal: tuple [
+MiDependencyStructuralMatrixBrowserModel >> isDiagonal: tuple [
 	^tuple key = tuple value
 
 ]
 
 { #category : #buildGraph }
-MiDSMBrowserModel >> newGraph [
+MiDependencyStructuralMatrixBrowserModel >> newGraph [
 	graph := AITarjan new.
 	orderedNodes := #()
 ]
 
 { #category : #accessing }
-MiDSMBrowserModel >> nodesOrdered [
+MiDependencyStructuralMatrixBrowserModel >> nodesOrdered [
 	^orderedNodes
 ]
 
 { #category : #buildGraph }
-MiDSMBrowserModel >> orderNodes [
+MiDependencyStructuralMatrixBrowserModel >> orderNodes [
 	"Store ordered nodes in #orderedNodes.
 	 Order is:
 	 - number of combined in and out dependencies
@@ -188,13 +188,13 @@ MiDSMBrowserModel >> orderNodes [
 ]
 
 { #category : #settings }
-MiDSMBrowserModel >> sccColor [
+MiDependencyStructuralMatrixBrowserModel >> sccColor [
 
 	^ nodeColors at: #scc
 ]
 
 { #category : #api }
-MiDSMBrowserModel >> sccTuplesForTuple: tuple [
+MiDependencyStructuralMatrixBrowserModel >> sccTuplesForTuple: tuple [
 	"gets the SCC owning tuple, then collects all tuples in this SCC
 	 where row entity depends on column entity"
 	| scc graphNode |
@@ -212,18 +212,18 @@ MiDSMBrowserModel >> sccTuplesForTuple: tuple [
 ]
 
 { #category : #accessing }
-MiDSMBrowserModel >> selectedEntities [
+MiDependencyStructuralMatrixBrowserModel >> selectedEntities [
 	^#()
 ]
 
 { #category : #settings }
-MiDSMBrowserModel >> showSCCColor [
+MiDependencyStructuralMatrixBrowserModel >> showSCCColor [
 
 	^ nodeColors at: #showSCC
 ]
 
 { #category : #api }
-MiDSMBrowserModel >> showSCCColorForTuple: tuple [
+MiDependencyStructuralMatrixBrowserModel >> showSCCColorForTuple: tuple [
 	"same as #colorForX:y: but highlighting SCCs"
 	(self isDiagonal: tuple) ifTrue: [ ^self diagonalColor ].
 	(self isDependency: tuple) ifFalse: [ ^self defaultColor ].

--- a/src/MooseIDE-Dependency/MiDependencyStructuralMatrixVisualization.class.st
+++ b/src/MooseIDE-Dependency/MiDependencyStructuralMatrixVisualization.class.st
@@ -2,7 +2,7 @@
 A visualization of a RSDSM inside a MooseIDE browser
 "
 Class {
-	#name : #MiDSMVisualization,
+	#name : #MiDependencyStructuralMatrixVisualization,
 	#superclass : #MiAbstractVisualization,
 	#instVars : [
 		'viewModel',
@@ -14,17 +14,17 @@ Class {
 }
 
 { #category : #coloring }
-MiDSMVisualization >> cellColor: tuple [
+MiDependencyStructuralMatrixVisualization >> cellColor: tuple [
 	^viewModel colorForTuple: tuple
 ]
 
 { #category : #coloring }
-MiDSMVisualization >> cellShowSCCColor: tuple [
+MiDependencyStructuralMatrixVisualization >> cellShowSCCColor: tuple [
 	^viewModel showSCCColorForTuple: tuple
 ]
 
 { #category : #initialization }
-MiDSMVisualization >> createDSM: aRSCanvas [
+MiDependencyStructuralMatrixVisualization >> createDSM: aRSCanvas [
 	| dsm entities |
 	"change legend by adding #noLegend to RSCanvasController new
 	and add RSLegend new ..."
@@ -33,7 +33,7 @@ MiDSMVisualization >> createDSM: aRSCanvas [
 	entities ifEmpty: [ ^self ].
 	
 	aRSCanvas addInteraction: RSCanvasController new.
-	dsm := MiRSDSM new.
+	dsm := MiRSDependencyStructuralMatrix new.
 	dsm owner: self.
 	dsm setShouldFeedY.
 	dsm labelShapeX textBlock: [ :columnNode | viewModel displayValueForNode: columnNode].
@@ -49,7 +49,7 @@ MiDSMVisualization >> createDSM: aRSCanvas [
 ]
 
 { #category : #initialization }
-MiDSMVisualization >> initialize [
+MiDependencyStructuralMatrixVisualization >> initialize [
 
 	super initialize.
 	self script: [ :canvas | self createDSM: canvas ].
@@ -59,7 +59,7 @@ MiDSMVisualization >> initialize [
 ]
 
 { #category : #private }
-MiDSMVisualization >> sccShapesIncluding: aRSShape [
+MiDependencyStructuralMatrixVisualization >> sccShapesIncluding: aRSShape [
 "Transcript
 	show: '    ';
 	show: (aRSShape model key model name) ;
@@ -75,7 +75,7 @@ MiDSMVisualization >> sccShapesIncluding: aRSShape [
 ]
 
 { #category : #initialization }
-MiDSMVisualization >> setInteractions: dsm [
+MiDependencyStructuralMatrixVisualization >> setInteractions: dsm [
 	|   |
 	dsm shapes @ (RSPopup text: [:tuple | viewModel displayValueForTuple: tuple ]).
 
@@ -96,18 +96,18 @@ MiDSMVisualization >> setInteractions: dsm [
 ]
 
 { #category : #utilities }
-MiDSMVisualization >> shapeFor: tuple [
+MiDependencyStructuralMatrixVisualization >> shapeFor: tuple [
 	currentCanvas deepShapeFromModel: tuple
 ]
 
 { #category : #coloring }
-MiDSMVisualization >> showSCC: aCollection [
+MiDependencyStructuralMatrixVisualization >> showSCC: aCollection [
 	aCollection do: [ :tuple |
 		(self shapeFor: tuple) color: (viewModel showSCCColorForTuple: tuple)
 	]
 ]
 
 { #category : #accessing }
-MiDSMVisualization >> viewModel: aDSMModel [
+MiDependencyStructuralMatrixVisualization >> viewModel: aDSMModel [
 	viewModel := aDSMModel
 ]

--- a/src/MooseIDE-Dependency/MiDistributionMapBrowser.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapBrowser.class.st
@@ -21,83 +21,83 @@ Controls:
 * R to clear all searches
 "
 Class {
-	#name : #MiDMBrowser,
+	#name : #MiDistributionMapBrowser,
 	#superclass : #MiAbstractVisualizationBrowser,
 	#category : #'MooseIDE-Dependency-DistributionMap'
 }
 
 { #category : #accessing }
-MiDMBrowser class >> mapClass [
+MiDistributionMapBrowser class >> mapClass [
 
-	^ MiDMVisualization
+	^ MiDistributionMapVisualization
 ]
 
 { #category : #'world menu' }
-MiDMBrowser class >> menuCommandOn: aBuilder [
+MiDistributionMapBrowser class >> menuCommandOn: aBuilder [
 
 	<worldMenu>
 	^ self buildMenuItemIn: aBuilder
 ]
 
 { #category : #'world menu' }
-MiDMBrowser class >> menuItem [
+MiDistributionMapBrowser class >> menuItem [
 
 	^ #DMBrowser
 ]
 
 { #category : #'world menu' }
-MiDMBrowser class >> menuPriority [
+MiDistributionMapBrowser class >> menuPriority [
 
 	^ self menuVisualizationToolsPriority + 5
 ]
 
 { #category : #'instance creation' }
-MiDMBrowser class >> newModel [
+MiDistributionMapBrowser class >> newModel [
 
 	^ MiDistributionMapModel new
 ]
 
 { #category : #'instance creation' }
-MiDMBrowser class >> open [
+MiDistributionMapBrowser class >> open [
 	<script>
-	super open
+	[super open] spy
 ]
 
 { #category : #specs }
-MiDMBrowser class >> title [
+MiDistributionMapBrowser class >> title [
 
 	^ 'Distribution map'
 ]
 
 { #category : #specs }
-MiDMBrowser class >> windowSize [
+MiDistributionMapBrowser class >> windowSize [
 
 	^ 850 @ 520
 ]
 
 { #category : #adding }
-MiDMBrowser >> addDynamicTags: aCollection [
+MiDistributionMapBrowser >> addDynamicTags: aCollection [
 
 	aCollection do: [ :dt | self model addDynamicTag: dt ].
 	"settings refreshTagList"
 ]
 
 { #category : #actions }
-MiDMBrowser >> availableQueries [
+MiDistributionMapBrowser >> availableQueries [
 
 	^ (self application itemsFor: FQAbstractQuery) asOrderedCollection 
 		  select: [ :q | q isValid ]
 ]
 
 { #category : #initialization }
-MiDMBrowser >> browserClosed [
+MiDistributionMapBrowser >> browserClosed [
 
 	super browserClosed.
 	application unregisterConsumer: self
 ]
 
 { #category : #actions }
-MiDMBrowser >> canFollowEntity: aCollection [
+MiDistributionMapBrowser >> canFollowEntity: aCollection [
 
 	| uniqType confirm |
 	aCollection isCollection ifFalse: [ ^false ].
@@ -130,32 +130,32 @@ Are you sure you want to continue ?
 ]
 
 { #category : #testing }
-MiDMBrowser >> canReceiveEntity: anEntity [
+MiDistributionMapBrowser >> canReceiveEntity: anEntity [
 
 	^ anEntity isMooseObject
 ]
 
 { #category : #initialization }
-MiDMBrowser >> canvas [
+MiDistributionMapBrowser >> canvas [
 
 	^ mainPresenter canvas
 ]
 
 { #category : #actions }
-MiDMBrowser >> followEntity: anEntity [
+MiDistributionMapBrowser >> followEntity: anEntity [
 
 	specModel entities: anEntity asMooseGroup.
 	self runVisualization
 ]
 
 { #category : #testing }
-MiDMBrowser >> hasSettings [
+MiDistributionMapBrowser >> hasSettings [
 
 	^ true
 ]
 
 { #category : #initialization }
-MiDMBrowser >> initializeLayout [
+MiDistributionMapBrowser >> initializeLayout [
 
 	self layout: (SpBoxLayout newLeftToRight
 			 spacing: 3;
@@ -164,14 +164,14 @@ MiDMBrowser >> initializeLayout [
 ]
 
 { #category : #initialization }
-MiDMBrowser >> initializePresenters [
+MiDistributionMapBrowser >> initializePresenters [
 
 	mainPresenter := self class mapClass owner: self.
 	self initializeLayout
 ]
 
 { #category : #initialization }
-MiDMBrowser >> visualization [
+MiDistributionMapBrowser >> visualization [
 
 	^ mainPresenter
 ]

--- a/src/MooseIDE-Dependency/MiDistributionMapBuilder.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapBuilder.class.st
@@ -57,12 +57,12 @@ MiDistributionMapBuilder >> buildNodeFromEntity: anEntity [
 		  name:
 			  (String streamContents: [ :s | anEntity displayStringOn: s ]);
 		  rawModel: anEntity;
-		  style: MiHDMStyle new;
+		  style: MiHDistributionMapStyle new;
 		  layout: self nodeLayout;
 		  addAll: ((self mapModel childrenFor: anEntity) collect: [ :n | 
 					   HNode new
 						   name: (String streamContents: [ :s | n displayStringOn: s ]);
-						   style: MiHDMStyle new;
+						   style: MiHDistributionMapStyle new;
 						   rawModel: n;
 						   yourself ]);
 		  expand;
@@ -98,7 +98,7 @@ MiDistributionMapBuilder >> mapModel: anObject [
 MiDistributionMapBuilder >> menuInteraction [
 	^ menuInteraction ifNil: [ 
 		menuInteraction := RSMenuActivable new
-			menuDo: [ :menu :aShape | MiDMMenuItem 
+			menuDo: [ :menu :aShape | MiDistributionMapMenuItem 
 				buildIn: menu 
 				shape: aShape 
 				visualization: self ];

--- a/src/MooseIDE-Dependency/MiDistributionMapInspectNodeMenuItem.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapInspectNodeMenuItem.class.st
@@ -2,28 +2,28 @@
 This menu item inspects a node with a moose inspector.
 "
 Class {
-	#name : #MiDMInspectNodeMenuItem,
-	#superclass : #MiDMNodeMenuItem,
+	#name : #MiDistributionMapInspectNodeMenuItem,
+	#superclass : #MiDistributionMapNodeMenuItem,
 	#category : #'MooseIDE-Dependency-DistributionMap'
 }
 
 { #category : #execution }
-MiDMInspectNodeMenuItem >> execute [
+MiDistributionMapInspectNodeMenuItem >> execute [
 
 	MiInspectorBrowser inspect: shape model rawModel
 ]
 
 { #category : #execution }
-MiDMInspectNodeMenuItem >> iconName [
+MiDistributionMapInspectNodeMenuItem >> iconName [
 	^ #smallInspectIt
 ]
 
 { #category : #execution }
-MiDMInspectNodeMenuItem >> label [
+MiDistributionMapInspectNodeMenuItem >> label [
 	^ 'Inspect'
 ]
 
 { #category : #execution }
-MiDMInspectNodeMenuItem >> order [
+MiDistributionMapInspectNodeMenuItem >> order [
 	^ 42
 ]

--- a/src/MooseIDE-Dependency/MiDistributionMapMenuItem.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapMenuItem.class.st
@@ -2,13 +2,13 @@
 Base class for distribution map menu.
 "
 Class {
-	#name : #MiDMMenuItem,
+	#name : #MiDistributionMapMenuItem,
 	#superclass : #HAbstractMenuItem,
 	#category : #'MooseIDE-Dependency-DistributionMap'
 }
 
 { #category : #public }
-MiDMMenuItem class >> buildIn: aMenuMorph shape: aRoassalShape visualization: anHSimpleVisualizationBuilder [
+MiDistributionMapMenuItem class >> buildIn: aMenuMorph shape: aRoassalShape visualization: anHSimpleVisualizationBuilder [
 	| items clazz |
 	clazz := self classFor: aRoassalShape.
 	items := clazz subclasses collect: #new.
@@ -25,12 +25,12 @@ MiDMMenuItem class >> buildIn: aMenuMorph shape: aRoassalShape visualization: an
 ]
 
 { #category : #public }
-MiDMMenuItem class >> classFor: aRoassalShape [
+MiDistributionMapMenuItem class >> classFor: aRoassalShape [
 	aRoassalShape isShape
 		ifFalse: [ ^ self ].
 	^ aRoassalShape isNode
 		ifTrue: [ 
-			MiDMNodeMenuItem ]
+			MiDistributionMapNodeMenuItem ]
 		ifFalse: [ self ]
 		
 ]

--- a/src/MooseIDE-Dependency/MiDistributionMapModel.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapModel.class.st
@@ -201,13 +201,10 @@ MiDistributionMapModel >> orderOuterNodes: aCollectionOfNodes [
 	| engine partVectors |
 	aCollectionOfNodes ifEmpty: [ ^ #(  ) ].
 
-	partVectors := aCollectionOfNodes collect: [ :node | 
-		AISimilarityItem
-			with: node
-			andAll: (self tagsSetting collect: [ :aProp | 
-				self
-					numberOfchildrenWithProperty: aProp
-					forNode: node ]) ] as: Array.
+	partVectors := aCollectionOfNodes
+		               collect: [ :node |
+		               AISimilarityItem with: node andAll: (self tagsSetting collect: [ :aProp | self numberOfchildrenWithProperty: aProp forNode: node ]) ]
+		               as: Array.
 	engine := AISeriationEngine with: partVectors.
 	^ engine orderDendrogramLeaves collect: #item
 ]

--- a/src/MooseIDE-Dependency/MiDistributionMapNodeMenuItem.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapNodeMenuItem.class.st
@@ -2,7 +2,7 @@
 Menu for nodes (i.e., containers and parts).
 "
 Class {
-	#name : #MiDMNodeMenuItem,
-	#superclass : #MiDMMenuItem,
+	#name : #MiDistributionMapNodeMenuItem,
+	#superclass : #MiDistributionMapMenuItem,
 	#category : #'MooseIDE-Dependency-DistributionMap'
 }

--- a/src/MooseIDE-Dependency/MiDistributionMapVisualization.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapVisualization.class.st
@@ -4,13 +4,13 @@ I am a visualization, using a builder to draw a distribution map [1] on my canva
 [1] S. Ducasse, T. Girba and A. Kuhn, ""Distribution Map,"" 2006 22nd IEEE International Conference on Software Maintenance, 2006, pp. 203-212, doi: 10.1109/ICSM.2006.22.
 "
 Class {
-	#name : #MiDMVisualization,
+	#name : #MiDistributionMapVisualization,
 	#superclass : #MiAbstractHierarchicalVisualization,
 	#category : #'MooseIDE-Dependency-DistributionMap'
 }
 
 { #category : #running }
-MiDMVisualization >> run [
+MiDistributionMapVisualization >> run [
 
 	super run.
 	builder := MiDistributionMapBuilder new

--- a/src/MooseIDE-Dependency/MiHDistributionMapStyle.class.st
+++ b/src/MooseIDE-Dependency/MiHDistributionMapStyle.class.st
@@ -2,7 +2,7 @@
 I am the class responsible of building shapes for the distribution map.
 "
 Class {
-	#name : #MiHDMStyle,
+	#name : #MiHDistributionMapStyle,
 	#superclass : #HStyle,
 	#instVars : [
 		'topCornerRadius',
@@ -12,7 +12,7 @@ Class {
 }
 
 { #category : #hooks }
-MiHDMStyle >> adjustLabel: aLabel ToWidth: width [
+MiHDistributionMapStyle >> adjustLabel: aLabel ToWidth: width [
 
 	| sizeOfNewText font text |
 	font := aLabel font.
@@ -25,14 +25,14 @@ MiHDMStyle >> adjustLabel: aLabel ToWidth: width [
 ]
 
 { #category : #hooks }
-MiHDMStyle >> bottomCornerRadius [
+MiHDistributionMapStyle >> bottomCornerRadius [
 	^ bottomCornerRadius ifNil: [ 
 		bottomCornerRadius := RSCornerRadius new 
 			bottom: self cornerRadius ]
 ]
 
 { #category : #hooks }
-MiHDMStyle >> buildCompositeEmptyNodeIn: shape [
+MiHDistributionMapStyle >> buildCompositeEmptyNodeIn: shape [
 
 	| node box rect |
 	node := shape model.
@@ -58,7 +58,7 @@ MiHDMStyle >> buildCompositeEmptyNodeIn: shape [
 ]
 
 { #category : #hooks }
-MiHDMStyle >> buildCompositeFullNodeIn: shape [
+MiHDistributionMapStyle >> buildCompositeFullNodeIn: shape [
 
 	| childrenShapes node titleGroup title titleBox children boxChildren titleRadius boxChildrenRadius list |
 	node := shape model.
@@ -122,25 +122,25 @@ MiHDMStyle >> buildCompositeFullNodeIn: shape [
 ]
 
 { #category : #hooks }
-MiHDMStyle >> cornerRadius [
+MiHDistributionMapStyle >> cornerRadius [
 
 	^ 7
 ]
 
 { #category : #hooks }
-MiHDMStyle >> elementWidth [
+MiHDistributionMapStyle >> elementWidth [
 
 	^ 10
 ]
 
 { #category : #hooks }
-MiHDMStyle >> emptyBoxExtent [
+MiHDistributionMapStyle >> emptyBoxExtent [
 
 	^ 30@20
 ]
 
 { #category : #hooks }
-MiHDMStyle >> iconFor: anHNode [
+MiHDistributionMapStyle >> iconFor: anHNode [
 	anHNode iconName ifNil: [ ^ nil ].
 	^ RSBitmap new
 		form: (self iconNamed: anHNode iconName);
@@ -149,7 +149,7 @@ MiHDMStyle >> iconFor: anHNode [
 ]
 
 { #category : #hooks }
-MiHDMStyle >> labelAndIconFor: anHNode [
+MiHDistributionMapStyle >> labelAndIconFor: anHNode [
 	| group icon |
 	group := RSGroup new.
 	icon := self iconFor: anHNode.
@@ -161,7 +161,7 @@ MiHDMStyle >> labelAndIconFor: anHNode [
 ]
 
 { #category : #hooks }
-MiHDMStyle >> shapeFor: aHNode [
+MiHDistributionMapStyle >> shapeFor: aHNode [
 
 	| shape |
 	shape := RSComposite new
@@ -175,7 +175,7 @@ MiHDMStyle >> shapeFor: aHNode [
 ]
 
 { #category : #hooks }
-MiHDMStyle >> topCornerRadius [
+MiHDistributionMapStyle >> topCornerRadius [
 	^ topCornerRadius ifNil: [ 
 		topCornerRadius := RSCornerRadius new 
 			top: self cornerRadius ]

--- a/src/MooseIDE-Dependency/MiRSDependencyStructuralMatrix.class.st
+++ b/src/MooseIDE-Dependency/MiRSDependencyStructuralMatrix.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #MiRSDSM,
+	#name : #MiRSDependencyStructuralMatrix,
 	#superclass : #RSDSM,
 	#instVars : [
 		'owner'
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #highlighting }
-MiRSDSM >> highlight: evt [
+MiRSDependencyStructuralMatrix >> highlight: evt [
 	super highlight: evt.
 	shape := nil.
 	(owner sccShapesIncluding: evt shape) do: [ :aShape |
@@ -17,13 +17,13 @@ MiRSDSM >> highlight: evt [
 ]
 
 { #category : #accessing }
-MiRSDSM >> owner: anObject [
+MiRSDependencyStructuralMatrix >> owner: anObject [
 
 	owner := anObject
 ]
 
 { #category : #highlighting }
-MiRSDSM >> unhighlight: evt [
+MiRSDependencyStructuralMatrix >> unhighlight: evt [
 	super unhighlight: evt.
 
 	(owner sccShapesIncluding: evt shape) do: [ :aShape |

--- a/src/MooseIDE-Tests/MiDependencyStructuralMatrixBrowserTest.class.st
+++ b/src/MooseIDE-Tests/MiDependencyStructuralMatrixBrowserTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #MiDSMBrowserTest,
+	#name : #MiDependencyStructuralMatrixBrowserTest,
 	#superclass : #MiAbstractBrowserTest,
 	#instVars : [
 		'entityToSelect'
@@ -8,25 +8,25 @@ Class {
 }
 
 { #category : #running }
-MiDSMBrowserTest >> browserClass [
-	^ MiDSMBrowser
+MiDependencyStructuralMatrixBrowserTest >> browserClass [
+	^ MiDependencyStructuralMatrixBrowser
 ]
 
 { #category : #running }
-MiDSMBrowserTest >> method: aName [
+MiDependencyStructuralMatrixBrowserTest >> method: aName [
 
 	^ FamixRepTestMethod named: aName
 ]
 
 { #category : #running }
-MiDSMBrowserTest >> setUp [
+MiDependencyStructuralMatrixBrowserTest >> setUp [
 	super setUp.
 
 	entityToSelect := { self method: 'method1' . self method: 'method2' . self method: 'method3' }
 ]
 
 { #category : #tests }
-MiDSMBrowserTest >> testActivateActionButtons [
+MiDependencyStructuralMatrixBrowserTest >> testActivateActionButtons [
 
 	browser actionButtons do: [ :button | self deny: button isEnabled ].
 
@@ -37,6 +37,6 @@ MiDSMBrowserTest >> testActivateActionButtons [
 ]
 
 { #category : #'tests - tags' }
-MiDSMBrowserTest >> testCanTagEntities [
+MiDependencyStructuralMatrixBrowserTest >> testCanTagEntities [
 	self deny: browser canTagEntities 
 ]

--- a/src/MooseIDE-Tests/MiDistributionMapBrowserTest.class.st
+++ b/src/MooseIDE-Tests/MiDistributionMapBrowserTest.class.st
@@ -1,17 +1,17 @@
 Class {
-	#name : #MiDMBrowserTest,
+	#name : #MiDistributionMapBrowserTest,
 	#superclass : #MiAbstractBrowserTest,
 	#category : #'MooseIDE-Tests-Browsers'
 }
 
 { #category : #running }
-MiDMBrowserTest >> browserClass [
+MiDistributionMapBrowserTest >> browserClass [
 
-	^ MiDMBrowser
+	^ MiDistributionMapBrowser
 ]
 
 { #category : #'tests - tags' }
-MiDMBrowserTest >> testSelectedTagSetAndGet [
+MiDistributionMapBrowserTest >> testSelectedTagSetAndGet [
 	| model entity tag |
 	model := FamixRepTestModel new.
 	tag := model tagNamed: 'aTag'.
@@ -23,13 +23,13 @@ MiDMBrowserTest >> testSelectedTagSetAndGet [
 ]
 
 { #category : #tests }
-MiDMBrowserTest >> testSettingsAction [
+MiDistributionMapBrowserTest >> testSettingsAction [
 
 	self assert: browser hasSettings
 ]
 
 { #category : #tests }
-MiDMBrowserTest >> testSettingsClickOK [
+MiDistributionMapBrowserTest >> testSettingsClickOK [
 	"overriding to setup the right context"
 
 	browser model entities: #().


### PR DESCRIPTION
I tried to find some classes about disctribution maps but that was hard because the names of those classes have "DM" in the name instead of "DistributionMap".

This is the same for DependencyStructuralMatrix. 

I propose to remove the abbreviations from the names to make it more explicit.