### PR TITLE
Fix the display of tags in the disctribution map settings

### DIFF
--- a/src/MooseIDE-Dependency/MiDistributionMapBrowser.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapBrowser.class.st
@@ -59,8 +59,9 @@ MiDistributionMapBrowser class >> newModel [
 
 { #category : #'instance creation' }
 MiDistributionMapBrowser class >> open [
+
 	<script>
-	[super open] spy
+	^ super open
 ]
 
 { #category : #specs }

--- a/src/MooseIDE-Dependency/MiDistributionMapModel.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapModel.class.st
@@ -121,10 +121,11 @@ MiDistributionMapModel >> fetchChildrenQueries [
 
 { #category : #accessing }
 MiDistributionMapModel >> fetchTags [
+	"If we ask the application, then we need the tag browser opened. So we asume a browser is opened on the entities of only one model and we ask the tags in the models of a random moose entity of the browser."
 
-	^ ((browser application itemsFor: MiDynamicTag)
-	   , (browser application itemsFor: FamixTag)) asOrderedCollection 
-		  sorted: [ :t1 :t2 | t1 name < t2 name ]
+	browser model entities ifNotNil: [ :ents | ents ifNotEmpty: [ ^ ents anyOne mooseModel allTags sorted: #name ascending ] ].
+
+	^ #(  )
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Currently to have some tags shown in the distribution map settings, we need the tag browser open to be a provider of tags which is not really user friendly. 

I propose another way to get the tags. Ideally we should have entities of only one model for the distribution map (except if we play by hand in a playground and propagate this..). So I now ask a random entity of the model and gets the tags from its model.

Fixes #985