### PR TITLE
New Architectural Map and other visualizations speed ups

### DIFF
--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -175,7 +175,7 @@ BaselineOfMooseIDE >> hierarchicalVisualizations: spec [
 
 	spec baseline: 'HierarchicalVisualizations' with: [
 		spec repository:
-			'github://moosetechnology/HierarchicalVisualizations:v1.0.2/src' ]
+			'github://moosetechnology/HierarchicalVisualizations:main/src' ]
 ]
 
 { #category : #dependencies }

--- a/src/MooseIDE-Dependency/MiArchitecturalMapBuilder.class.st
+++ b/src/MooseIDE-Dependency/MiArchitecturalMapBuilder.class.st
@@ -316,7 +316,7 @@ MiArchitecturalMapBuilder >> initialize [
 
 	super initialize.
 	nodeMooseIDDict := Dictionary new.
-	allEntities := MooseGroup new.
+	allEntities := OrderedCollection new.
 	tagNodes := OrderedCollection new.
 	nodesToAdd := Dictionary new
 ]

--- a/src/MooseIDE-Dependency/MiArchitecturalMapModel.class.st
+++ b/src/MooseIDE-Dependency/MiArchitecturalMapModel.class.st
@@ -119,7 +119,7 @@ MiArchitecturalMapModel >> childrenFor: anEntity [
 	^ virtualEntities
 		  at: anEntity
 		  ifPresent: [ :children | children ]
-		  ifAbsent: [ (self childrenQuerySetting rawRunOn: anEntity asMooseGroup) asArray ]
+		  ifAbsent: [ (self childrenQuerySetting rawRunOnEntity: anEntity) asArray ]
 ]
 
 { #category : #settings }


### PR DESCRIPTION
This change speeds up once again the Architectural map and the other visu using the hierarchical. 

- Use a simple OrderedCollections instead of a MooseGroup
- Depend on the main branch of HierarchicalVisualizations project that got some improvements
- Use the new #rawRunOnEntity: that is more efficient