### PR TITLE
[FIX}: Replacing button with editable list setting by button with selectable list setting

### DIFF
--- a/src/MooseIDE-Core/MiButtonEditablelistSettingItem.class.st
+++ b/src/MooseIDE-Core/MiButtonEditablelistSettingItem.class.st
@@ -8,19 +8,7 @@ Class {
 }
 
 { #category : #accessing }
-MiButtonEditablelistSettingItem >> display: aBlock [
-
-	secondaryPresenter display: aBlock
-]
-
-{ #category : #accessing }
 MiButtonEditablelistSettingItem >> displayBlock: aBlock [
-
-	secondaryPresenter displayIcon: aBlock
-]
-
-{ #category : #accessing }
-MiButtonEditablelistSettingItem >> displayIcon: aBlock [
 
 	secondaryPresenter displayIcon: aBlock
 ]

--- a/src/MooseIDE-Core/MiButtonListSettingItem.class.st
+++ b/src/MooseIDE-Core/MiButtonListSettingItem.class.st
@@ -7,6 +7,18 @@ Class {
 	#category : #'MooseIDE-Core-Settings'
 }
 
+{ #category : #accessing }
+MiButtonListSettingItem >> display: aBlock [
+
+	secondaryPresenter display: aBlock
+]
+
+{ #category : #accessing }
+MiButtonListSettingItem >> displayIcon: aBlock [
+
+	secondaryPresenter displayIcon: aBlock
+]
+
 { #category : #updating }
 MiButtonListSettingItem >> possibleValues: aList [
 

--- a/src/MooseIDE-Dependency/MiDistributionMapModel.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapModel.class.st
@@ -173,13 +173,14 @@ MiDistributionMapModel >> itemColorForNoTag [
 { #category : #settings }
 MiDistributionMapModel >> itemTags [
 
-	^ MiAbstractSettingItem buttonWithEditableListSetting
+	^ MiAbstractSettingItem buttonWithSelectableListSetting
 		  possibleValues: self fetchTags;
 		  displayIcon: [ :tag | MiTagBrowserModel iconForTag: tag ];
 		  display: [ :tag | tag name ];
 		  label: 'Tags';
 		  help: 'The tags used as properties to display.
 If an entity has several tags, it will get the color of the first of its tags appearing in the list';
+		  selectAll;
 		  yourself
 ]
 


### PR DESCRIPTION
Moving `display:` and `displayIcon:` to `MiButtonListSettingItem` wich is the superclass of `MiButtonEditablelistSettingItem` and `MiButtonSelectableListSettingItem`