### PR TITLE
Fix architectural map

### DIFF
--- a/src/MooseIDE-Dependency/MiArchitecturalMapBuilder.class.st
+++ b/src/MooseIDE-Dependency/MiArchitecturalMapBuilder.class.st
@@ -253,7 +253,7 @@ MiArchitecturalMapBuilder >> createRootNodes [
 
 	^ (mapModel rootNodes
 		   collect: [ :e | self buildNodeFromEntity: e ]
-		) sort: [ :a :b | a name < b name ]
+		   thenReject: [ :node | node isNil ]) sort: [ :a :b | a name < b name ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
buildNodeFromEntity: is returning nils but createRootNodes was not taking them into account. Now it does.

Fixes #999