### PR TITLE
Architectural: Open nodes on double click + speed up

### DIFF
--- a/src/MooseIDE-Dependency/MiArchitecturalMapBuilder.class.st
+++ b/src/MooseIDE-Dependency/MiArchitecturalMapBuilder.class.st
@@ -317,21 +317,20 @@ MiArchitecturalMapBuilder >> menuItemStrategy [
 
 { #category : #accessing }
 MiArchitecturalMapBuilder >> nodeAnnouncer [
-
 	"plug new events here"
 
 	baseNode ifNotNil: [ ^ baseNode announcer ].
 	baseNode := RSComposite new
 		            @ self popup;
-		            @
-			            (HGhostDraggable new color:
-					             Smalltalk ui theme caretColor);
+		            @ (HGhostDraggable new color: Smalltalk ui theme caretColor);
 		            @ self menuInteraction;
 		            @ self highlightable;
 		            @ self highlightableLinkedShapes;
 		            @ RSNodeOnTopWhenPositionChanged new;
 		            @ HResizeParentWhenChildMoves new;
 		            yourself.
+
+	baseNode when: RSMouseDoubleLeftClick do: [ :event | event shape model expandCollapse ] for: self.
 	^ baseNode announcer
 ]
 

--- a/src/MooseIDE-Dependency/MiArchitecturalMapStyle.class.st
+++ b/src/MooseIDE-Dependency/MiArchitecturalMapStyle.class.st
@@ -19,17 +19,17 @@ MiArchitecturalMapStyle >> colorFor: node [
 ]
 
 { #category : #hooks }
-MiArchitecturalMapStyle >> createMultiTagBoxSized: aSize [
+MiArchitecturalMapStyle >> createMultiTagBox [
 
 	| cp |
 	cp := RSComposite new.
-	cp addAll: ({ 
+	cp addAll: ({
 			 Color red.
 			 Color cyan.
 			 Color green.
-			 Color yellow } collect: [ :color | 
+			 Color yellow } collect: [ :color |
 			 RSBox new
-				 size: aSize / 2;
+				 size: 7;
 				 color: color;
 				 yourself ]).
 	RSGridLayout new
@@ -50,24 +50,57 @@ MiArchitecturalMapStyle >> labelAndIconFor: node [
 	| group entity |
 	group := super labelAndIconFor: node.
 	entity := node rawModel.
-	(entity notNil and: [ entity isTag not and: [ entity isTagged ] ]) ifTrue: [
-		| tag |
-		tag := entity allTags first.
+	(entity isNotNil and: [ entity isTag not and: [ entity isTagged ] ]) ifTrue: [
 		group addFirst: (RSCircle new
-				 color: tag color;
+				 color: entity tags first color;
 				 radius: 7;
 				 yourself) ].
-	node children ifNotEmpty: [
-		| tags |
-		tags := node allChildren flatCollectAsSet: [ :childNode | childNode rawModel tags ].
-		tags size = 1 ifTrue: [
-			group addLast: (RSBox new
-					 color: tags anyOne color;
-					 size: 14;
-					 yourself) ].
-		tags size > 1 ifTrue: [ group addLast: (self createMultiTagBoxSized: 14) ] ].
+	node children ifNotEmpty: [ (self tagIconFor: node) ifNotNil: [ :icon | group addLast: icon ] ].
 	RSHorizontalLineLayout new
 		alignMiddle;
 		on: group.
 	^ group
+]
+
+{ #category : #hooks }
+MiArchitecturalMapStyle >> tagIconFor: node [
+	"We could just do a #flatCollectAsSet: of the tags on the #allChildren but this can be pretty long to do. And in the end we just want to know if there is 0, 1 or multiple tags so here is an optimized version.
+	
+	We optimize because we want to avoid to go to the deepest children when we find tags on upper levels and we also want to avoid collecting all possbile tags when the first children already have some.
+	This is ugly code but that improves quite a bit the vizualization speed.
+	
+	It could be simpler doing: 
+	
+		| tags |
+		tags := node allChildren flatCollectAsSet: [ :childNode | childNode rawModel tags ].
+		tags size = 1 ifTrue: [
+			^(RSBox new
+					 color: tags anyOne color;
+					 size: 14;
+					 yourself) ].
+		tags size > 1 ifTrue: [ ^ self createMultiTagBox ].
+		
+		^ nil"
+
+	| childrenToCheck foundTag lookupBlock |
+	lookupBlock := [ :entity |
+	               entity tags ifNotEmpty: [ :tags |
+		               tags size = 1
+			               ifTrue: [
+				               foundTag
+					               ifNil: [ foundTag := tags anyOne ]
+					               ifNotNil: [ ^ self createMultiTagBox ] ]
+			               ifFalse: [ ^ self createMultiTagBox ] ] ].
+
+	childrenToCheck := node children.
+
+	[ childrenToCheck isEmpty ] whileFalse: [
+		childrenToCheck do: [ :childNode | lookupBlock value: childNode rawModel ].
+		childrenToCheck := childrenToCheck flatCollect: #children ].
+
+	^ foundTag ifNotNil: [
+		  ^ RSBox new
+			    color: foundTag color;
+			    size: 14;
+			    yourself ]
 ]


### PR DESCRIPTION
This change allows one to open/collapse nodes with a double click instead of going in the menus. This also speed up the opening of the nodes that is pretty slow on big models.

Fixes #1018