### PR TITLE
Architectural: Do not show multi tags if all tags are the same

### DIFF
--- a/src/MooseIDE-Dependency/MiArchitecturalMapStyle.class.st
+++ b/src/MooseIDE-Dependency/MiArchitecturalMapStyle.class.st
@@ -89,7 +89,8 @@ MiArchitecturalMapStyle >> tagIconFor: node [
 			               ifTrue: [
 				               foundTag
 					               ifNil: [ foundTag := tags anyOne ]
-					               ifNotNil: [ ^ self createMultiTagBox ] ]
+					               ifNotNil: [ "We have multiple tags in the found one is different than the currently found tag"
+					               foundTag = tags anyOne ifFalse: [ ^ self createMultiTagBox ] ] ]
 			               ifFalse: [ ^ self createMultiTagBox ] ] ].
 
 	childrenToCheck := node children.


### PR DESCRIPTION
Currently in the architectural visualization if an entity contains multiple time the same tag it'll have a multi tag icon instead of an icon for the specific tag.

This fixes it.