### PR TITLE
MiArchitecturalMapBrowser>>open should return the instance

### DIFF
--- a/src/MooseIDE-Dependency/MiArchitecturalMapBrowser.class.st
+++ b/src/MooseIDE-Dependency/MiArchitecturalMapBrowser.class.st
@@ -59,8 +59,9 @@ MiArchitecturalMapBrowser class >> newModel [
 
 { #category : #'instance creation' }
 MiArchitecturalMapBrowser class >> open [
+
 	<script>
-	super open
+	^ super open
 ]
 
 { #category : #specs }


### PR DESCRIPTION
MiArchitecturalMapBrowser>>open currently returns MiArchitecturalMapBrowser class but it should return the opened instance.

This is to help me script the manipulation of browsers for Moose security