### PR TITLE
Increase playground model selection windows extent

### DIFF
--- a/src/MooseIDE-NewTools/MiPlaygroundModelsPresenter.class.st
+++ b/src/MooseIDE-NewTools/MiPlaygroundModelsPresenter.class.st
@@ -69,7 +69,9 @@ MiPlaygroundModelsPresenter >> initializePresenters [
 MiPlaygroundModelsPresenter >> initializeWindow: aWindowPresenter [
 
 	super initializeWindow: aWindowPresenter.
-	aWindowPresenter title: self class defaultTitle
+	aWindowPresenter
+		title: self class defaultTitle;
+		initialExtent: 800 @ 400
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Make the window to select a model in the playground bigger at opening (Usability problem reported by Anne)