### PR TITLE
Sort queries a bit smarter.

### DIFF
--- a/src/MooseIDE-QueriesBrowser/FQAbstractQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQAbstractQuery.extension.st
@@ -18,5 +18,22 @@ FQAbstractQuery >> allChildren: aCollection [
 { #category : #'*MooseIDE-QueriesBrowser' }
 FQAbstractQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
 
-	^ false
+	^ self isAbstract not and: [
+		  numberOfQueriesInPresenter >= self minimumQueriesSize ]
+]
+
+{ #category : #'*MooseIDE-QueriesBrowser' }
+FQAbstractQuery class >> minimumQueriesSize [
+
+	self subclassResponsibility
+]
+
+{ #category : #'*MooseIDE-QueriesBrowser' }
+FQAbstractQuery class >> threeWayCompareTo: anotherQuery [
+
+	self minimumQueriesSize = anotherQuery minimumQueriesSize ifTrue: [
+		^ self label threeWayCompareTo: anotherQuery label ].
+
+	^ self minimumQueriesSize threeWayCompareTo:
+		  anotherQuery minimumQueriesSize
 ]

--- a/src/MooseIDE-QueriesBrowser/FQBooleanQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQBooleanQuery.extension.st
@@ -7,12 +7,6 @@ FQBooleanQuery class >> canBeConfigured [
 ]
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQBooleanQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ true
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQBooleanQuery class >> miPresenterClass [
 
 	^ MiBooleanQueryPresenter

--- a/src/MooseIDE-QueriesBrowser/FQComplementQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQComplementQuery.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #FQComplementQuery }
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQComplementQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ numberOfQueriesInPresenter > 0
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQComplementQuery class >> miPresenterClass [
 
 	^ MiNegationQueryPresenter
+]
+
+{ #category : #'*MooseIDE-QueriesBrowser' }
+FQComplementQuery class >> minimumQueriesSize [
+
+	^ 1
 ]

--- a/src/MooseIDE-QueriesBrowser/FQIntersectionQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQIntersectionQuery.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #FQIntersectionQuery }
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
-FQIntersectionQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ numberOfQueriesInPresenter > 1
-]

--- a/src/MooseIDE-QueriesBrowser/FQNAryQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQNAryQuery.extension.st
@@ -5,3 +5,9 @@ FQNAryQuery class >> miPresenterClass [
 
 	^ MiNAryQueryPresenter
 ]
+
+{ #category : #'*MooseIDE-QueriesBrowser' }
+FQNAryQuery class >> minimumQueriesSize [
+
+	^ 2
+]

--- a/src/MooseIDE-QueriesBrowser/FQNavigationQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQNavigationQuery.extension.st
@@ -6,12 +6,6 @@ FQNavigationQuery class >> canBeConfigured [
 ]
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQNavigationQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ true
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQNavigationQuery >> isNavigationQuery [
 
 	^ true

--- a/src/MooseIDE-QueriesBrowser/FQNullQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQNullQuery.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FQNullQuery }
+
+{ #category : #'*MooseIDE-QueriesBrowser' }
+FQNullQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ false
+]

--- a/src/MooseIDE-QueriesBrowser/FQNumericQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQNumericQuery.extension.st
@@ -7,12 +7,6 @@ FQNumericQuery class >> canBeConfigured [
 ]
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQNumericQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ true
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQNumericQuery class >> miPresenterClass [
 
 	^ MiNumericQueryPresenter

--- a/src/MooseIDE-QueriesBrowser/FQRelationQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQRelationQuery.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #FQRelationQuery }
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQRelationQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ true
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQRelationQuery class >> miPresenterClass [
 
 	^ MiRelationQueryPresenter

--- a/src/MooseIDE-QueriesBrowser/FQResultSizeQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQResultSizeQuery.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #FQResultSizeQuery }
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQResultSizeQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ numberOfQueriesInPresenter > 0
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQResultSizeQuery class >> miPresenterClass [
 
 	^ MiResultSizeQueryPresenter
+]
+
+{ #category : #'*MooseIDE-QueriesBrowser' }
+FQResultSizeQuery class >> minimumQueriesSize [
+
+	^ 1
 ]

--- a/src/MooseIDE-QueriesBrowser/FQRootQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQRootQuery.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FQRootQuery }
+
+{ #category : #'*MooseIDE-QueriesBrowser' }
+FQRootQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ false
+]

--- a/src/MooseIDE-QueriesBrowser/FQScopeQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQScopeQuery.extension.st
@@ -6,12 +6,6 @@ FQScopeQuery class >> canBeConfigured [
 ]
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQScopeQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ true
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQScopeQuery >> isScopeQuery [
 
 	^ true

--- a/src/MooseIDE-QueriesBrowser/FQScriptQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQScriptQuery.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FQScriptQuery }
+
+{ #category : #'*MooseIDE-QueriesBrowser' }
+FQScriptQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
+
+	^ false
+]

--- a/src/MooseIDE-QueriesBrowser/FQStringQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQStringQuery.extension.st
@@ -7,12 +7,6 @@ FQStringQuery class >> canBeConfigured [
 ]
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQStringQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ true
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQStringQuery class >> miPresenterClass [
 
 	^ MiStringQueryPresenter

--- a/src/MooseIDE-QueriesBrowser/FQSubtractionQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQSubtractionQuery.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #FQSubtractionQuery }
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
-FQSubtractionQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ numberOfQueriesInPresenter > 1
-]

--- a/src/MooseIDE-QueriesBrowser/FQTaggedEntityQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQTaggedEntityQuery.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #FQTaggedEntityQuery }
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQTaggedEntityQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ true
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQTaggedEntityQuery class >> miPresenterClass [
 	^ MiTaggedEntityQueryPresenter
 ]

--- a/src/MooseIDE-QueriesBrowser/FQTypeQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQTypeQuery.extension.st
@@ -6,12 +6,6 @@ FQTypeQuery class >> canBeConfigured [
 ]
 
 { #category : #'*MooseIDE-QueriesBrowser' }
-FQTypeQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ true
-]
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
 FQTypeQuery class >> miPresenterClass [
 
 	^ MiTypeQueryPresenter

--- a/src/MooseIDE-QueriesBrowser/FQUnaryQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQUnaryQuery.extension.st
@@ -4,3 +4,9 @@ Extension { #name : #FQUnaryQuery }
 FQUnaryQuery class >> canBeConfigured [
 	^ false
 ]
+
+{ #category : #'*MooseIDE-QueriesBrowser' }
+FQUnaryQuery class >> minimumQueriesSize [
+
+	^ 0
+]

--- a/src/MooseIDE-QueriesBrowser/FQUnionQuery.extension.st
+++ b/src/MooseIDE-QueriesBrowser/FQUnionQuery.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #FQUnionQuery }
-
-{ #category : #'*MooseIDE-QueriesBrowser' }
-FQUnionQuery class >> isAvailableForQueriesSize: numberOfQueriesInPresenter [
-
-	^ numberOfQueriesInPresenter > 1
-]

--- a/src/MooseIDE-QueriesBrowser/MiQueryListItemPresenter.class.st
+++ b/src/MooseIDE-QueriesBrowser/MiQueryListItemPresenter.class.st
@@ -149,14 +149,13 @@ MiQueryListItemPresenter >> initializePresenters [
 { #category : #initialization }
 MiQueryListItemPresenter >> initializeQueryTypesDropList [
 
-	| sortedItems |
 	queryTypesDropListPresenter := self newDropList.
-	sortedItems := queriesListPresenter availableQueryTypes sorted: #label ascending.
+
 	queryTypesDropListPresenter
 		startWithoutSelection;
-		items: sortedItems;
+		items: self sortedAvailableQueries;
 		display: [ :queryClass | queryClass label ];
-		whenSelectedItemChangedDo: [ :queryClass | 
+		whenSelectedItemChangedDo: [ :queryClass |
 			self updateQueryConfiguratorPresenterFor: queryClass ]
 ]
 
@@ -244,6 +243,13 @@ MiQueryListItemPresenter >> setModelBeforeInitialization: aQuery [
 MiQueryListItemPresenter >> setQueryNumber: anInteger [
 
 	queryNumberLabelPresenter label: anInteger asString
+]
+
+{ #category : #initialization }
+MiQueryListItemPresenter >> sortedAvailableQueries [
+
+	^ queriesListPresenter availableQueryTypes sorted:
+		  #yourself ascending
 ]
 
 { #category : #update }


### PR DESCRIPTION
Fix #1005.
Queries are now sorted by their arity before being sorted alphabetically. I would have loved to add separators in the droplist but Spec did not want me to.