### PR TITLE
Search Moose entities using the spotter

### DIFF
--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -155,7 +155,9 @@ BaselineOfMooseIDE >> definePackages: spec [
 		package: 'MooseIDE-ClassBlueprint'
 		with: [
 			spec requires: #( 'MooseIDE-Visualization' 'ClassBlueprint' ) ];
-		package: 'MooseIDE-Spotter'.
+		package: 'MooseIDE-Spotter';
+		package: 'MooseIDE-Spotter-Tests'
+		with: [ spec requires: #( 'MooseIDE-Spotter' ) ].
 
 	self defineMooseCriticsPackages: spec
 ]

--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -93,42 +93,69 @@ BaselineOfMooseIDE >> definePackages: spec [
 
 	spec
 		package: 'MooseIDE-Colors' with: [ spec requires: #( 'Roassal' ) ];
-		package: 'MooseIDE-Colors-Tests' with: [ spec requires: #( 'MooseIDE-Colors' ) ];
-		
-		package: 'MooseIDE-Core' with: [ spec requires: #( 'MooseIDE-Colors' 'LabelContractor' 'RoassalExporters' ) ];
-		
-		package: 'MooseIDE-Visualization' with: [ spec requires: #( 'MooseIDE-Core' 'HierarchicalVisualizations' ) ];
-		
-		package: 'MooseIDE-Meta' with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Famix' ) ];
-		
-		package: 'MooseIDE-Dependency' with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' 'Roassal' 'AIHierarchicalClustering' ) ];
-		
-		package: 'MooseIDE-Tests' with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Dependency' 'MooseIDE-Visualization' ) ];
-		
+		package: 'MooseIDE-Colors-Tests'
+		with: [ spec requires: #( 'MooseIDE-Colors' ) ];
+		package: 'MooseIDE-Core' with: [
+			spec requires:
+					#( 'MooseIDE-Colors' 'LabelContractor' 'RoassalExporters' ) ];
+		package: 'MooseIDE-Visualization'
+		with: [
+			spec requires: #( 'MooseIDE-Core' 'HierarchicalVisualizations' ) ];
+		package: 'MooseIDE-Meta'
+		with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Famix' ) ];
+		package: 'MooseIDE-Dependency' with: [
+			spec requires:
+					#( 'MooseIDE-Core' 'MooseIDE-Visualization'
+					   'Roassal' 'AIHierarchicalClustering' ) ];
+		package: 'MooseIDE-Tests' with: [
+			spec requires:
+					#( 'MooseIDE-Core' 'MooseIDE-Dependency' 'MooseIDE-Visualization' ) ];
 		package: 'MooseIDE-AttributedText';
-		package: 'MooseIDE-Famix' with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' 'MooseIDE-AttributedText') ];
-		
-		package: 'MooseIDE-QueriesBrowser' with: [ spec requires: #( 'MooseIDE-Core' 'FamixQueries' ) ];
-		package: 'MooseIDE-QueriesBrowser-Tests' with: [ spec requires: #( 'MooseIDE-QueriesBrowser' 'MooseIDE-Tests' ) ];
-		
-		package: 'MooseIDE-Tagging' with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' ) ];
-		package: 'MooseIDE-Tagging-Tests' with: [ spec requires: #( 'MooseIDE-Tagging' 'MooseIDE-Tests' ) ];
-		
-		package: 'MooseIDE-CoUsageMap' with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' ) ];
-		package: 'MooseIDE-CoUsageMap-Tests' with: [ spec requires: #( 'MooseIDE-CoUsageMap' 'MooseIDE-Tests' ) ];
-		
-		package: 'MooseIDE-NewTools' with: [ spec requires: #( 'MooseIDE-Meta' 'MooseIDE-Core' 'FamixQueries' ) ];
-		package: 'MooseIDE-NewTools-Tests' with: [ spec requires: #( 'MooseIDE-NewTools' 'MooseIDE-Tests' ) ];
-		
-		package: 'MooseIDE-Export' with: [ spec requires: #( 'MooseIDE-Core' 'InteractiveNotebook' ) ];
-
-		package: 'MooseIDE-Duplication' with: [ spec requires: #( 'MooseIDE-Core' ) ];
-		
-		package: 'MooseIDE-ButterflyMap' with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' ) ];
-		package: 'MooseIDE-ButterflyMap-Tests' with: [ spec requires: #( 'MooseIDE-ButterflyMap' ) ];
-		package: 'MooseIDE-QueriesDashboard' with: [ spec requires: #( 'MooseIDE-Core' ) ];
-		package: 'MooseIDE-LayerVisualization' with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' 'MooseIDE-QueriesDashboard' ) ];
-		package: 'MooseIDE-ClassBlueprint'with: [ spec requires: #( 'MooseIDE-Visualization' 'ClassBlueprint' )].
+		package: 'MooseIDE-Famix' with: [
+			spec requires:
+					#( 'MooseIDE-Core' 'MooseIDE-Visualization'
+					   'MooseIDE-AttributedText' ) ];
+		package: 'MooseIDE-QueriesBrowser'
+		with: [ spec requires: #( 'MooseIDE-Core' 'FamixQueries' ) ];
+		package: 'MooseIDE-QueriesBrowser-Tests'
+		with: [
+			spec requires: #( 'MooseIDE-QueriesBrowser'
+				   'MooseIDE-Tests' ) ];
+		package: 'MooseIDE-Tagging'
+		with: [
+			spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' ) ];
+		package: 'MooseIDE-Tagging-Tests'
+		with: [ spec requires: #( 'MooseIDE-Tagging' 'MooseIDE-Tests' ) ];
+		package: 'MooseIDE-CoUsageMap'
+		with: [
+			spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' ) ];
+		package: 'MooseIDE-CoUsageMap-Tests'
+		with: [ spec requires: #( 'MooseIDE-CoUsageMap'
+				   'MooseIDE-Tests' ) ];
+		package: 'MooseIDE-NewTools'
+		with: [
+			spec requires: #( 'MooseIDE-Meta' 'MooseIDE-Core' 'FamixQueries' ) ];
+		package: 'MooseIDE-NewTools-Tests'
+		with: [ spec requires: #( 'MooseIDE-NewTools' 'MooseIDE-Tests' ) ];
+		package: 'MooseIDE-Export'
+		with: [ spec requires: #( 'MooseIDE-Core' 'InteractiveNotebook' ) ];
+		package: 'MooseIDE-Duplication'
+		with: [ spec requires: #( 'MooseIDE-Core' ) ];
+		package: 'MooseIDE-ButterflyMap'
+		with: [
+			spec requires: #( 'MooseIDE-Core' 'MooseIDE-Visualization' ) ];
+		package: 'MooseIDE-ButterflyMap-Tests'
+		with: [ spec requires: #( 'MooseIDE-ButterflyMap' ) ];
+		package: 'MooseIDE-QueriesDashboard'
+		with: [ spec requires: #( 'MooseIDE-Core' ) ];
+		package: 'MooseIDE-LayerVisualization' with: [
+			spec requires:
+					#( 'MooseIDE-Core' 'MooseIDE-Visualization'
+					   'MooseIDE-QueriesDashboard' ) ];
+		package: 'MooseIDE-ClassBlueprint'
+		with: [
+			spec requires: #( 'MooseIDE-Visualization' 'ClassBlueprint' ) ];
+		package: 'MooseIDE-Spotter'.
 
 	self defineMooseCriticsPackages: spec
 ]

--- a/src/MooseIDE-Spotter-Tests/StMooseProcessorTest.class.st
+++ b/src/MooseIDE-Spotter-Tests/StMooseProcessorTest.class.st
@@ -33,8 +33,33 @@ StMooseProcessorTest >> tearDown [
 ]
 
 { #category : #tests }
+StMooseProcessorTest >> testEmptyEvenWithExistingModel [
+
+	| stModel aStClass |
+	stModel := FamixStModel new.
+	aStClass := stModel newClassNamed: 'aClass'.
+	stModel install.
+
+	self runForText: ''.
+	self assertQuantityOfResults: 0
+]
+
+{ #category : #tests }
 StMooseProcessorTest >> testEmptyQueryShowsNoResult [
 
 	self runForText: ''.
 	self assertQuantityOfResults: 0
+]
+
+{ #category : #tests }
+StMooseProcessorTest >> testOneNamedClassUsingFamixSt [
+
+	| stModel aStClass |
+	stModel := FamixStModel new.
+	aStClass := stModel newClassNamed: 'aClass'.
+	stModel install.
+
+	self runForText: 'aCl'.
+	self assertQuantityOfResults: 1.
+	self assertResultsIncludes: aStClass
 ]

--- a/src/MooseIDE-Spotter-Tests/StMooseProcessorTest.class.st
+++ b/src/MooseIDE-Spotter-Tests/StMooseProcessorTest.class.st
@@ -1,0 +1,8 @@
+"
+A StMooseProcessorTest is a test class for testing the behavior of StMooseProcessor
+"
+Class {
+	#name : #StMooseProcessorTest,
+	#superclass : #StAbstractProcessorTest,
+	#category : #'MooseIDE-Spotter-Tests'
+}

--- a/src/MooseIDE-Spotter-Tests/StMooseProcessorTest.class.st
+++ b/src/MooseIDE-Spotter-Tests/StMooseProcessorTest.class.st
@@ -16,15 +16,15 @@ StMooseProcessorTest >> processor [
 	^ StMooseProcessor new 
 ]
 
-{ #category : #tests }
+{ #category : #running }
 StMooseProcessorTest >> setUp [
 
+	super setUp.
 	existingRoot := MooseModelRoot installedRoot.
-	MooseModelRoot resetRoot.
-	super setUp
+	MooseModelRoot resetRoot
 ]
 
-{ #category : #tests }
+{ #category : #running }
 StMooseProcessorTest >> tearDown [
 
 	MooseModelRoot resetRoot.

--- a/src/MooseIDE-Spotter-Tests/StMooseProcessorTest.class.st
+++ b/src/MooseIDE-Spotter-Tests/StMooseProcessorTest.class.st
@@ -4,5 +4,37 @@ A StMooseProcessorTest is a test class for testing the behavior of StMooseProces
 Class {
 	#name : #StMooseProcessorTest,
 	#superclass : #StAbstractProcessorTest,
+	#instVars : [
+		'existingRoot'
+	],
 	#category : #'MooseIDE-Spotter-Tests'
 }
+
+{ #category : #tests }
+StMooseProcessorTest >> processor [
+
+	^ StMooseProcessor new 
+]
+
+{ #category : #tests }
+StMooseProcessorTest >> setUp [
+
+	existingRoot := MooseModelRoot installedRoot.
+	MooseModelRoot resetRoot.
+	super setUp
+]
+
+{ #category : #tests }
+StMooseProcessorTest >> tearDown [
+
+	MooseModelRoot resetRoot.
+	MooseModelRoot installRoot: existingRoot.
+	super tearDown
+]
+
+{ #category : #tests }
+StMooseProcessorTest >> testEmptyQueryShowsNoResult [
+
+	self runForText: ''.
+	self assertQuantityOfResults: 0
+]

--- a/src/MooseIDE-Spotter-Tests/package.st
+++ b/src/MooseIDE-Spotter-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'MooseIDE-Spotter-Tests' }

--- a/src/MooseIDE-Spotter/FamixTSourceEntity.extension.st
+++ b/src/MooseIDE-Spotter/FamixTSourceEntity.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #FamixTSourceEntity }
+
+{ #category : #'*MooseIDE-Spotter' }
+FamixTSourceEntity >> spotterPreview: aBuilder [
+
+	^ aBuilder newCode
+		  beNotEditable;
+		  text: self sourceText;
+		  yourself
+]

--- a/src/MooseIDE-Spotter/StMooseEntry.class.st
+++ b/src/MooseIDE-Spotter/StMooseEntry.class.st
@@ -19,7 +19,7 @@ StMooseEntry >> doEvaluate [
 { #category : #accessing }
 StMooseEntry >> iconName [
 
-	^ content systemIconName
+	^ #mooseIcon
 ]
 
 { #category : #accessing }

--- a/src/MooseIDE-Spotter/StMooseEntry.class.st
+++ b/src/MooseIDE-Spotter/StMooseEntry.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : #StMooseEntry,
+	#superclass : #StEntry,
+	#category : #'MooseIDE-Spotter'
+}
+
+{ #category : #converting }
+StMooseEntry >> asString [
+
+	^ content mooseName
+]
+
+{ #category : #evaluating }
+StMooseEntry >> doEvaluate [
+
+	^ content inspect
+]
+
+{ #category : #accessing }
+StMooseEntry >> iconName [
+
+	^ content systemIconName
+]
+
+{ #category : #accessing }
+StMooseEntry >> label [
+
+	^ content printString
+]

--- a/src/MooseIDE-Spotter/StMooseProcessor.class.st
+++ b/src/MooseIDE-Spotter/StMooseProcessor.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : #StMooseProcessor,
+	#superclass : #StSpotterProcessor,
+	#category : #'MooseIDE-Spotter'
+}
+
+{ #category : #'default-settings' }
+StMooseProcessor class >> defaultEnabled [
+
+	^ true
+]
+
+{ #category : #'default-settings' }
+StMooseProcessor class >> order [
+	
+	^ 900
+]
+
+{ #category : #'default-settings' }
+StMooseProcessor class >> title [
+
+	^ 'Moose'
+]
+
+{ #category : #filtering }
+StMooseProcessor >> newTextFilteringSource [
+
+	^ ((StCollectionIterator on:
+		    (MooseModel root anyOne allUsing: FamixTNamedEntity))
+		   collect: [ :e | StMooseEntry on: e ]) asSubstringFilter
+]

--- a/src/MooseIDE-Spotter/StMooseProcessor.class.st
+++ b/src/MooseIDE-Spotter/StMooseProcessor.class.st
@@ -25,7 +25,8 @@ StMooseProcessor class >> title [
 { #category : #filtering }
 StMooseProcessor >> newTextFilteringSource [
 
-	^ ((StCollectionIterator on:
-		    (MooseModel root anyOne allUsing: FamixTNamedEntity))
+	^ ((StCollectionIterator on: (MooseModel root
+			     ifEmpty: [ {  } ]
+			     ifNotEmpty: [ :root | root anyOne allUsing: FamixTNamedEntity ]))
 		   collect: [ :e | StMooseEntry on: e ]) asSubstringFilter
 ]

--- a/src/MooseIDE-Spotter/package.st
+++ b/src/MooseIDE-Spotter/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'MooseIDE-Spotter' }


### PR DESCRIPTION
With this PR, it is possible to searcg using the spotter some Moose entities.
(I added the basic infrastructure here, it can be improved a lot to display additional information)

![image](https://github.com/moosetechnology/MooseIDE/assets/6225039/eb33836e-5471-401c-ae7c-010f7929c849)

When you perform a search, it automatically search through the first moose model. 
If there is a lot of data, search in the spotter for the "#Moose" category.

This idea comes from the old moosebook in which the feature was implemented.