### PR TITLE
Fix #1070: Propagate from popup menu respects chosen buses

### DIFF
--- a/src/MooseIDE-Core/MooseObject.extension.st
+++ b/src/MooseIDE-Core/MooseObject.extension.st
@@ -15,5 +15,12 @@ MooseObject >> miDescription [
 { #category : #'*MooseIDE-Core' }
 MooseObject >> miPropagate [
 
-	(MiApplication current busNamed: MiApplication defaultBusName ) globallySelect: self.
+	(MiApplication current busNamed: MiApplication defaultBusName)
+		globallySelect: self
+]
+
+{ #category : #'*MooseIDE-Core' }
+MooseObject >> miPropagateTo: buses [
+
+	buses do: [ :bus | bus globallySelect: self ]
 ]

--- a/src/MooseIDE-Tests/HMiPropagateMenuItemTest.class.st
+++ b/src/MooseIDE-Tests/HMiPropagateMenuItemTest.class.st
@@ -5,23 +5,29 @@ Class {
 }
 
 { #category : #tests }
-HMiPropagateMenuItemTest >> testPropagetMenuItem [
+HMiPropagateMenuItemTest >> testPropagateMenuItem [
+
 	| root node visualization shape items |
 	root := HNode new name: 'Visualization'.
-	node := HNode new name: 'aNode'; rawModel: (FamixStClass new name: 'AClass' ; yourself).
+	node := HNode new
+		        name: 'aNode';
+		        rawModel: (FamixStClass new
+				         name: 'AClass';
+				         yourself).
 	root add: node.
-	
-	visualization := HSimpleVisualizationBuilder new
-		rootNode: root;
-		build;
-		yourself.
-	
-	shape := visualization canvas shapeFromModel: node.
-	items := (HMenuBuilder new 
-		buildIn: MenuMorph new 
-		shape: shape 
-		visualization: visualization)
-		menuItemsFor: shape.
 
-	self assert: (items detect: [:menuItem | menuItem class = HMiPropagateMenuItem]) notNil.
+	visualization := HSimpleVisualizationBuilder new
+		                 rootNode: root;
+		                 build;
+		                 yourself.
+
+	shape := visualization canvas shapeFromModel: node.
+	items := (HMenuBuilder new
+		          buildIn: MenuMorph new
+		          shape: shape
+		          visualization: visualization) menuItemsFor: shape.
+
+	self assert: (items
+			 detect: [ :menuItem | menuItem class == HMiPropagateMenuItem ]
+			 ifNone: [ nil ]) isNotNil
 ]

--- a/src/MooseIDE-Visualization/HMiPropagateMenuItem.class.st
+++ b/src/MooseIDE-Visualization/HMiPropagateMenuItem.class.st
@@ -7,6 +7,14 @@ Class {
 	#category : #'MooseIDE-Visualization-Helpers'
 }
 
+{ #category : #accessing }
+HMiPropagateMenuItem >> argument [
+	"Propagate on the buses selected by the browser"
+
+	^ visualization mapModel ifNotNil: [ :mapModel |
+		  mapModel browser buses ]
+]
+
 { #category : #testing }
 HMiPropagateMenuItem >> canBeExecuted [
 	^ shape model rawModel isMooseEntity
@@ -34,7 +42,7 @@ HMiPropagateMenuItem >> order [
 
 { #category : #accessing }
 HMiPropagateMenuItem >> selector [
-	^ #miPropagate
+	^ #miPropagateTo:
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
I also wanted to add a test but there's too much stuff to setup and I got fed up, so here's what I got so far:
```st
testPropagateToSelectedBuses

	| bus browser receivingBrowser root node visualization shape propagate model |
	bus := MiBus named: 'TestBus'.
	browser := MiSystemComplexityBrowser new followBus: bus.
	receivingBrowser := MiClassBlueprintBrowser new followBus: bus.

	model := FamixStClass named: 'AClass'.
	root := HNode new name: 'Visualization'.
	node := HNode new
		        name: 'aNode';
		        rawModel: model.
	root add: node.

	visualization := HSimpleVisualizationBuilder new
		                 rootNode: root;
		                 build.
	browser	runVisualization.

	propagate := HMiPropagateMenuItem new
		             shape: (visualization canvas shapeFromModel: node);
		             visualization: visualization.

	"Trigger the propagate menu item."
	propagate target
		perform: propagate selector
		withArguments: propagate argument.

	self assert: receivingBrowser miSelectedItem identicalTo: model
```