### PR TITLE
Add a command to be able to parser, import and install java projects

### DIFF
--- a/src/MooseIDE-Meta/MiImportCommand.class.st
+++ b/src/MooseIDE-Meta/MiImportCommand.class.st
@@ -18,9 +18,7 @@ Class {
 { #category : #converting }
 MiImportCommand class >> addToSpCommandGroup: aSpCommandGroup forSpecContext: aPresenter [
 
-	{ 
-		MiImportFromFileCommand.
-		MiImportFromSTCommand } do: [ :cmd | 
+	self allSubclasses do: [ :cmd |
 		aSpCommandGroup register: ((cmd forSpecContext: aPresenter)
 				 iconName: cmd defaultIconName;
 				 yourself) ].

--- a/src/MooseIDE-Meta/MiImportModelDialog.class.st
+++ b/src/MooseIDE-Meta/MiImportModelDialog.class.st
@@ -12,7 +12,11 @@ Class {
 
 { #category : #opening }
 MiImportModelDialog class >> open [
-	^ self subclassResponsibility
+
+	<script>
+	^ self new
+		  openDialog;
+		  yourself
 ]
 
 { #category : #accessing }

--- a/src/MooseIDE-Meta/MiImportModelFromFileDialog.class.st
+++ b/src/MooseIDE-Meta/MiImportModelFromFileDialog.class.st
@@ -34,9 +34,7 @@ MiImportModelFromFileDialog class >> fullWindowExtent [
 MiImportModelFromFileDialog class >> open [
 
 	<script>
-	^ self new
-		  openDialog;
-		  yourself
+	^ super open
 ]
 
 { #category : #accessing }
@@ -54,10 +52,7 @@ MiImportModelFromFileDialog class >> windowExtent [
 { #category : #action }
 MiImportModelFromFileDialog >> closeEntitiesChoice [
 
-	self withWindowDo: [ :window | 
-		window extent: self class windowExtent ].
-
-	self layout: self simpleLayout
+	self withWindowDo: [ :window | window extent: self class windowExtent ]
 ]
 
 { #category : #initialization }
@@ -65,6 +60,52 @@ MiImportModelFromFileDialog >> connectPresenters [
 
 	mooseModelDroplist whenSelectionChangedDo: [ 
 		customEntitiesButton state ifTrue: [ self openEntitiesChoice ] ]
+]
+
+{ #category : #initialization }
+MiImportModelFromFileDialog >> defaultLayout [
+
+	| spacing size labelWidth |
+	spacing := 10.
+	size := 25.
+	labelWidth := 120.
+	^ SpBoxLayout newTopToBottom
+		  spacing: spacing;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: spacing;
+				   add: 'File path:' width: labelWidth;
+				   add: filePathInput;
+				   add: filePathButton width: size;
+				   yourself)
+		  height: size;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: spacing;
+				   add: 'Model type:' width: labelWidth;
+				   add: mooseModelDroplist;
+				   yourself)
+		  height: size;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: spacing;
+				   add: 'Model name:' width: labelWidth;
+				   add: modelNameInput;
+				   add: self newNullPresenter width: size;
+				   yourself)
+		  height: size;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: spacing;
+				   add: 'Root folder (optional):' width: labelWidth;
+				   add: rootFolderInput;
+				   add: rootFolderButton width: size;
+				   yourself)
+		  height: size;
+		  add: (SpBoxLayout newLeftToRight
+				   spacing: spacing;
+				   add: 'Entity types:' width: labelWidth;
+				   add: allEntitiesButton;
+				   add: customEntitiesButton;
+				   yourself)
+		  height: size;
+		  yourself
 ]
 
 { #category : #private }
@@ -187,12 +228,6 @@ MiImportModelFromFileDialog >> initializeFilePathWidgets [
 ]
 
 { #category : #initialization }
-MiImportModelFromFileDialog >> initializeLayout [
-
-	self layout: self simpleLayout
-]
-
-{ #category : #initialization }
 MiImportModelFromFileDialog >> initializeMooseModelDroplist [
 
 	mooseModelDroplist := self newDropList
@@ -218,9 +253,7 @@ MiImportModelFromFileDialog >> initializePresenters [
 		                    action: [ self getRootFolder ];
 		                    icon: (self iconNamed: #open).
 
-	self initializeEntitiesSelectionWidgets.
-
-	self initializeLayout
+	self initializeEntitiesSelectionWidgets
 ]
 
 { #category : #'metamodel-guess' }
@@ -290,52 +323,6 @@ MiImportModelFromFileDialog >> privateImportModel [
 	model name: (modelNameInput text ifEmpty: [ 'MooseModel' ]).
 
 	^ model
-]
-
-{ #category : #initialization }
-MiImportModelFromFileDialog >> simpleLayout [
-
-	| spacing size labelWidth |
-	spacing := 10.
-	size := 25.
-	labelWidth := 120.
-	^ SpBoxLayout newTopToBottom
-		  spacing: spacing;
-		  add: (SpBoxLayout newLeftToRight
-				   spacing: spacing;
-				   add: 'File path:' width: labelWidth;
-				   add: filePathInput;
-				   add: filePathButton width: size;
-				   yourself)
-		  height: size;
-		  add: (SpBoxLayout newLeftToRight
-				   spacing: spacing;
-				   add: 'Model type:' width: labelWidth;
-				   add: mooseModelDroplist;
-				   yourself)
-		  height: size;
-		  add: (SpBoxLayout newLeftToRight
-				   spacing: spacing;
-				   add: 'Model name:' width: labelWidth;
-				   add: modelNameInput;
-				   add: self newNullPresenter width: size;
-				   yourself)
-		  height: size;
-		  add: (SpBoxLayout newLeftToRight
-				   spacing: spacing;
-				   add: 'Root folder (optional):' width: labelWidth;
-				   add: rootFolderInput;
-				   add: rootFolderButton width: size;
-				   yourself)
-		  height: size;
-		  add: (SpBoxLayout newLeftToRight
-				   spacing: spacing;
-				   add: 'Entity types:' width: labelWidth;
-				   add: allEntitiesButton;
-				   add: customEntitiesButton;
-				   yourself)
-		  height: size;
-		  yourself
 ]
 
 { #category : #private }

--- a/src/MooseIDE-Meta/MiImportModelFromFoldersDialog.class.st
+++ b/src/MooseIDE-Meta/MiImportModelFromFoldersDialog.class.st
@@ -6,6 +6,12 @@ For now, I only work with Java and the latest version of VerveineJ. In the futur
 Class {
 	#name : #MiImportModelFromFoldersDialog,
 	#superclass : #MiImportModelDialog,
+	#instVars : [
+		'description',
+		'foldersList',
+		'addFolderButton',
+		'addFoldersButton'
+	],
 	#category : #'MooseIDE-Meta-Import'
 }
 
@@ -25,18 +31,73 @@ MiImportModelFromFoldersDialog class >> title [
 { #category : #accessing }
 MiImportModelFromFoldersDialog class >> windowExtent [
 
-	^ 600 @ 250
+	^ 600 @ 500
+]
+
+{ #category : #initialization }
+MiImportModelFromFoldersDialog >> connectPresenters [
+
+	super connectPresenters.
+	self flag: #todo. "In the future UIManager should be removed to use the spec selection tool but it is not possible since we still run on Pharo 11"
+	addFolderButton action: [
+		(UIManager default chooseDirectory: 'Select a project folder to add.') ifNotNil: [ :folder |
+			foldersList items add: folder.
+			foldersList refresh ] ].
+	addFoldersButton action: [
+		(UIManager default chooseDirectory: 'Select a folder contaninig only project folders to add.') ifNotNil: [ :folder |
+			foldersList items addAll: folder directories.
+			foldersList refresh ] ]
 ]
 
 { #category : #layout }
 MiImportModelFromFoldersDialog >> defaultLayout [
 
-	^ SpGridLayout new
+	^ SpBoxLayout newTopToBottom
+		  spacing: 3;
+		  add: description;
+		  add: foldersList;
+		  add: (SpBoxLayout newLeftToRight
+				   add: addFolderButton expand: false;
+				   add: addFoldersButton expand: false;
+				   yourself)
+		  expand: false;
+		  yourself
+]
+
+{ #category : #initialization }
+MiImportModelFromFoldersDialog >> initializePresenters [
+
+	super initializePresenters.
+	description := self newText.
+	foldersList := self newList.
+	addFolderButton := self newButton.
+	addFoldersButton := self newButton.
+
+	description
+		text: self userDescription;
+		beNotEditable.
+
+	foldersList items: OrderedCollection new.
+
+	addFolderButton
+		label: 'Add Folder';
+		iconName: #add.
+	addFoldersButton
+		label: 'Add Folders';
+		iconName: #add
 ]
 
 { #category : #action }
 MiImportModelFromFoldersDialog >> privateImportModel [
 1halt
+]
+
+{ #category : #'as yet unclassified' }
+MiImportModelFromFoldersDialog >> userDescription [
+
+	^ 'I am in interface to easily parse projects and import the resulting models into Moose.
+For now I am only working for Java projects. This might change in the future depending on the needs Moose users have.
+Bellow, you can select folders containing each a project to parse with the latest version of VerveineJ. If you wish to use your own VerveineJ version, a setting is available.'
 ]
 
 { #category : #action }

--- a/src/MooseIDE-Meta/MiImportModelFromFoldersDialog.class.st
+++ b/src/MooseIDE-Meta/MiImportModelFromFoldersDialog.class.st
@@ -64,6 +64,12 @@ MiImportModelFromFoldersDialog >> defaultLayout [
 		  yourself
 ]
 
+{ #category : #action }
+MiImportModelFromFoldersDialog >> importModel [
+
+	^ self privateImportModel
+]
+
 { #category : #initialization }
 MiImportModelFromFoldersDialog >> initializePresenters [
 
@@ -89,10 +95,17 @@ MiImportModelFromFoldersDialog >> initializePresenters [
 
 { #category : #action }
 MiImportModelFromFoldersDialog >> privateImportModel [
-1halt
+
+	^ MiMooseModelsWrapper models: (FamixJavaFoldersImporter importFolders: self selectedFolders)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
+MiImportModelFromFoldersDialog >> selectedFolders [
+
+	^ foldersList items
+]
+
+{ #category : #accessing }
 MiImportModelFromFoldersDialog >> userDescription [
 
 	^ 'I am in interface to easily parse projects and import the resulting models into Moose.
@@ -102,5 +115,7 @@ Bellow, you can select folders containing each a project to parse with the lates
 
 { #category : #action }
 MiImportModelFromFoldersDialog >> validateImportForm [
-	1halt
+
+	self selectedFolders ifEmpty: [ self error: 'Please select at least one folder.' ].
+	self selectedFolders do: [ :folder | folder ifAbsent: [ self error: 'Selected folder does not exist.' ] ]
 ]

--- a/src/MooseIDE-Meta/MiImportModelFromFoldersDialog.class.st
+++ b/src/MooseIDE-Meta/MiImportModelFromFoldersDialog.class.st
@@ -1,0 +1,45 @@
+"
+I am a presenter that will allow the user to select one or multiple folders and that will generate a json file for each one. Then I'll import those files in the model browser.
+
+For now, I only work with Java and the latest version of VerveineJ. In the future we could add other languages.
+"
+Class {
+	#name : #MiImportModelFromFoldersDialog,
+	#superclass : #MiImportModelDialog,
+	#category : #'MooseIDE-Meta-Import'
+}
+
+{ #category : #opening }
+MiImportModelFromFoldersDialog class >> open [
+
+	<script>
+	^ super open
+]
+
+{ #category : #specs }
+MiImportModelFromFoldersDialog class >> title [
+
+	^ 'Parse and import models from folders'
+]
+
+{ #category : #accessing }
+MiImportModelFromFoldersDialog class >> windowExtent [
+
+	^ 600 @ 250
+]
+
+{ #category : #layout }
+MiImportModelFromFoldersDialog >> defaultLayout [
+
+	^ SpGridLayout new
+]
+
+{ #category : #action }
+MiImportModelFromFoldersDialog >> privateImportModel [
+1halt
+]
+
+{ #category : #action }
+MiImportModelFromFoldersDialog >> validateImportForm [
+	1halt
+]

--- a/src/MooseIDE-Meta/MiImportModelFromSmalltalkDialog.class.st
+++ b/src/MooseIDE-Meta/MiImportModelFromSmalltalkDialog.class.st
@@ -19,22 +19,6 @@ Class {
 	#category : #'MooseIDE-Meta-Import'
 }
 
-{ #category : #layout }
-MiImportModelFromSmalltalkDialog class >> defaultLayout [
-
-	^ SpBoxLayout newTopToBottom
-		  spacing: 10;
-		  add: (SpBoxLayout newLeftToRight
-				   add: 'Model name: ' width: 100;
-				   add: #modelNameField;
-				   yourself)
-		  height: self inputTextHeight;
-		  add: 'Select packages: ' height: self inputTextHeight;
-		  add: #packagesSelector;
-		  add: #advancedSettingsButton height: self buttonHeight;
-		  yourself
-]
-
 { #category : #accessing }
 MiImportModelFromSmalltalkDialog class >> fullWindowExtent [
 
@@ -45,7 +29,7 @@ MiImportModelFromSmalltalkDialog class >> fullWindowExtent [
 MiImportModelFromSmalltalkDialog class >> open [
 
 	<script>
-	^ self new openDialog
+	^ super open
 ]
 
 { #category : #specs }
@@ -95,6 +79,22 @@ MiImportModelFromSmalltalkDialog >> advancedSettingsLayout [
 MiImportModelFromSmalltalkDialog >> candidateClass [
 
 	^ invocationStrategyDroplist selectedItem
+]
+
+{ #category : #layout }
+MiImportModelFromSmalltalkDialog >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  spacing: 10;
+		  add: (SpBoxLayout newLeftToRight
+				   add: 'Model name: ' width: 100;
+				   add: modelNameField;
+				   yourself)
+		  height: self class inputTextHeight;
+		  add: 'Select packages: ' height: self class inputTextHeight;
+		  add: packagesSelector;
+		  add: advancedSettingsButton height: self class buttonHeight;
+		  yourself
 ]
 
 { #category : #'advanced settings' }

--- a/src/MooseIDE-Meta/MiMooseModelsWrapper.class.st
+++ b/src/MooseIDE-Meta/MiMooseModelsWrapper.class.st
@@ -1,0 +1,40 @@
+"
+Most model importers of Moose IDE are importing one model and the browser got planned like this. 
+
+But it is possible to have an importer importing multiple models. I am here to make it compatible to import one or mulitple models.
+"
+Class {
+	#name : #MiMooseModelsWrapper,
+	#superclass : #Object,
+	#instVars : [
+		'models'
+	],
+	#category : #'MooseIDE-Meta-Import'
+}
+
+{ #category : #accessing }
+MiMooseModelsWrapper class >> models: aCollection [
+
+	^ self new
+		  models: aCollection;
+		  yourself
+]
+
+{ #category : #initialization }
+MiMooseModelsWrapper >> initialize [
+
+	super initialize.
+	models := OrderedCollection new
+]
+
+{ #category : #actions }
+MiMooseModelsWrapper >> install [
+
+	models do: [ :model | model install ]
+]
+
+{ #category : #accessing }
+MiMooseModelsWrapper >> models: aCollection [
+
+	models := aCollection
+]

--- a/src/MooseIDE-Meta/MiParseAndImportFromFoldersCommand.class.st
+++ b/src/MooseIDE-Meta/MiParseAndImportFromFoldersCommand.class.st
@@ -1,0 +1,38 @@
+"
+I am a command to open a presenter that will allow the user to parse and import some projects all at once.
+"
+Class {
+	#name : #MiParseAndImportFromFoldersCommand,
+	#superclass : #MiImportCommand,
+	#category : #'MooseIDE-Meta-Import'
+}
+
+{ #category : #default }
+MiParseAndImportFromFoldersCommand class >> defaultDescription [
+
+	^ 'This action allows one to select one or multiple folders and to parse all of them then import the generated json files in Moose.'
+]
+
+{ #category : #accessing }
+MiParseAndImportFromFoldersCommand class >> defaultIcon [
+
+	^ MooseIcons mooseTree
+]
+
+{ #category : #accessing }
+MiParseAndImportFromFoldersCommand class >> defaultIconName [
+
+	^ #mooseTree
+]
+
+{ #category : #default }
+MiParseAndImportFromFoldersCommand class >> defaultName [
+
+	^ 'Parse and import folders'
+]
+
+{ #category : #accessing }
+MiParseAndImportFromFoldersCommand class >> importForm [
+
+	^ MiImportModelFromFoldersDialog
+]


### PR DESCRIPTION
This PR adds a command to be able to select java projects on disk, download the latest VerveineJ, parse the projects and import the generated models.

This should allow us to remove MooseEasy 