### PR TITLE
Change the names of the buttons in Critic Browser for Context and Rule

### DIFF
--- a/src/MooseIDE-CriticBrowser/MiCBEditContextPresenter.class.st
+++ b/src/MooseIDE-CriticBrowser/MiCBEditContextPresenter.class.st
@@ -68,7 +68,7 @@ MiCBEditContextPresenter >> initializePresenters [
 	editButton := self newButton.
 	cancelButton := self newButton.
 	
-	editButton label: 'Edit context';
+	editButton label: 'Confirm';
 		icon: (self iconNamed: #glamorousEdit);
 		action: [ self editButtonAction ].
 		

--- a/src/MooseIDE-CriticBrowser/MiCBEditRulePresenter.class.st
+++ b/src/MooseIDE-CriticBrowser/MiCBEditRulePresenter.class.st
@@ -74,7 +74,7 @@ MiCBEditRulePresenter >> initializePresenters [
 	editButton := self newButton.
 	cancelButton := self newButton.
 	
-	editButton label: 'Edit rule';
+	editButton label: 'Confirm';
 		icon: (self iconNamed: #glamorousEdit);
 		action: [ self editButtonAction ].
 		


### PR DESCRIPTION
- Update MiCBEditContextPresenter >> initializePresenters  and  MiCBditRulePresenter >> initializePresenters to have "Confirm" button instead of "Edit rule" and "Edit context"

- Fix #1116