### PR TITLE
fix #1115

### DIFF
--- a/src/MooseIDE-ButterflyMap/MiButterflyMapBrowser.class.st
+++ b/src/MooseIDE-ButterflyMap/MiButterflyMapBrowser.class.st
@@ -87,6 +87,7 @@ MiButterflyMapBrowser >> canFollowEntity: anObject [
 { #category : #actions }
 MiButterflyMapBrowser >> followEntity: anEntity [
 
+	super followEntity: anEntity.
 	self model currentEntity: anEntity
 ]
 

--- a/src/MooseIDE-ClassBlueprint/MiClassBlueprintBrowser.class.st
+++ b/src/MooseIDE-ClassBlueprint/MiClassBlueprintBrowser.class.st
@@ -52,8 +52,7 @@ MiClassBlueprintBrowser >> canFollowEntity: anObject [
 { #category : #testing }
 MiClassBlueprintBrowser >> followEntity: anEntity [
 
-	self withWindowDo: [ :window |
-		window title: 'Blueprint of' , anEntity name ].
+	super followEntity: anEntity.
 	blueprint
 		type: anEntity;
 		run

--- a/src/MooseIDE-CoUsageMap/MiCoUsageMapBrowser.class.st
+++ b/src/MooseIDE-CoUsageMap/MiCoUsageMapBrowser.class.st
@@ -103,6 +103,8 @@ MiCoUsageMapBrowser >> connectPresenters [
 
 { #category : #actions }
 MiCoUsageMapBrowser >> followEntity: anEntity [
+
+	super followEntity: anEntity.
 	self model followEntity: anEntity
 ]
 

--- a/src/MooseIDE-Core/MiAbstractBrowser.class.st
+++ b/src/MooseIDE-Core/MiAbstractBrowser.class.st
@@ -332,6 +332,12 @@ MiAbstractBrowser class >> taskbarIcon [
 
 ]
 
+{ #category : #accessing }
+MiAbstractBrowser class >> titleForModelName: mooseModelName [
+
+	^ self title , ' (' , mooseModelName , ')'
+]
+
 { #category : #specs }
 MiAbstractBrowser class >> windowSize [
 
@@ -441,8 +447,8 @@ MiAbstractBrowser >> followBus: aBus [
 
 { #category : #actions }
 MiAbstractBrowser >> followEntity: anEntity [
-
-	^ self subclassResponsibility
+   anEntity ifNotNil: [ self updateWindowTitleWith: anEntity ].
+	
 ]
 
 { #category : #actions }
@@ -683,4 +689,15 @@ MiAbstractBrowser >> unfollowBus: aBus [
 MiAbstractBrowser >> updateToolbar [
 
 	self window ifNotNil: [ :window | window updateToolbar ]
+]
+
+{ #category : #actions }
+MiAbstractBrowser >> updateWindowTitleWith: anEntity [
+
+	| modelName |
+	modelName := (anEntity isMooseObject and: [ anEntity isMooseModel ])
+		             ifTrue: [ anEntity name ]
+		             ifFalse: [ anEntity printString ].
+	self withWindowDo: [ :window |
+		window title: (self class titleForModelName: modelName) ]
 ]

--- a/src/MooseIDE-CriticBrowser/MiCriticBrowser.class.st
+++ b/src/MooseIDE-CriticBrowser/MiCriticBrowser.class.st
@@ -224,6 +224,7 @@ MiCriticBrowser >> exportRulesToStream: aStream [
 
 { #category : #actions }
 MiCriticBrowser >> followEntity: anEntity [
+	super followEntity: anEntity .
 	self model setEntities: anEntity.
 	self updateEntitiesList: specModel entities.
 	self updateRulesList.

--- a/src/MooseIDE-Dependency/MiArchitecturalMapBrowser.class.st
+++ b/src/MooseIDE-Dependency/MiArchitecturalMapBrowser.class.st
@@ -123,6 +123,7 @@ MiArchitecturalMapBrowser >> doWithTimeout: aBlock [
 { #category : #actions }
 MiArchitecturalMapBrowser >> followEntity: anEntity [
 
+	super followEntity: anEntity.
 	specModel entities: anEntity asMooseGroup.
 	self runVisualization
 ]

--- a/src/MooseIDE-Dependency/MiDependencyStructuralMatrixBrowser.class.st
+++ b/src/MooseIDE-Dependency/MiDependencyStructuralMatrixBrowser.class.st
@@ -114,6 +114,8 @@ MiDependencyStructuralMatrixBrowser >> diagram [
 
 { #category : #actions }
 MiDependencyStructuralMatrixBrowser >> followEntity: anEntity [
+
+	super followEntity: anEntity.
 	specModel followEntity: anEntity
 ]
 

--- a/src/MooseIDE-Dependency/MiDistributionMapBrowser.class.st
+++ b/src/MooseIDE-Dependency/MiDistributionMapBrowser.class.st
@@ -145,6 +145,7 @@ MiDistributionMapBrowser >> canvas [
 { #category : #actions }
 MiDistributionMapBrowser >> followEntity: anEntity [
 
+	super followEntity: anEntity.
 	specModel entities: anEntity asMooseGroup.
 	self runVisualization
 ]

--- a/src/MooseIDE-Duplication/MiDuplicationBrowser.class.st
+++ b/src/MooseIDE-Duplication/MiDuplicationBrowser.class.st
@@ -93,9 +93,10 @@ MiDuplicationBrowser >> canHighlight [
 ]
 
 { #category : #actions }
-MiDuplicationBrowser >> followEntity: entityCollection [
+MiDuplicationBrowser >> followEntity: anEntity [
 
-	specModel entities: entityCollection
+	super followEntity: anEntity.
+	specModel entities: anEntity
 ]
 
 { #category : #actions }

--- a/src/MooseIDE-Export/MiNotebookBrowser.class.st
+++ b/src/MooseIDE-Export/MiNotebookBrowser.class.st
@@ -90,6 +90,7 @@ MiNotebookBrowser >> canFollowEntity: anObject [
 { #category : #actions }
 MiNotebookBrowser >> followEntity: anEntity [
 
+	super followEntity: anEntity.
 	specModel mooseModel: anEntity mooseModel.
 	notebook addBinding: 'mooseModel' -> anEntity mooseModel
 ]

--- a/src/MooseIDE-Famix/MiSourceTextBrowser.class.st
+++ b/src/MooseIDE-Famix/MiSourceTextBrowser.class.st
@@ -102,12 +102,12 @@ MiSourceTextBrowser >> externalEditor: anObject [
 { #category : #actions }
 MiSourceTextBrowser >> followEntity: anEntity [
 
+	super followEntity: anEntity.
 	specModel displayedEntity: anEntity.
 	textRenderer renderText.
 
-	self updateWindowTitleWith: anEntity name.
 
-	toolBarExternalEditor newEntity.
+	toolBarExternalEditor newEntity
 ]
 
 { #category : #initialization }
@@ -139,13 +139,6 @@ MiSourceTextBrowser >> toolBarExternalEditor [
 MiSourceTextBrowser >> toolBarExternalEditor: anObject [
 	"only for testing"
 	toolBarExternalEditor := anObject
-]
-
-{ #category : #actions }
-MiSourceTextBrowser >> updateWindowTitleWith: aName [
-
-	self withWindowDo: [ :window | 
-		window title: self class title , ' of ' , aName ]
 ]
 
 { #category : #formatting }

--- a/src/MooseIDE-Famix/MiUMLBrowser.class.st
+++ b/src/MooseIDE-Famix/MiUMLBrowser.class.st
@@ -95,6 +95,7 @@ MiUMLBrowser >> canTagEntities [
 { #category : #actions }
 MiUMLBrowser >> followEntity: anEntity [
 
+	super followEntity: anEntity.
 	specModel
 		entities: anEntity asMooseSpecializedGroup;
 		unselectAll.

--- a/src/MooseIDE-LayerVisualization/MiLayerVisualizationBrowser.class.st
+++ b/src/MooseIDE-LayerVisualization/MiLayerVisualizationBrowser.class.st
@@ -54,6 +54,7 @@ MiLayerVisualizationBrowser >> canFollowEntity: anObject [
 MiLayerVisualizationBrowser >> followEntity: anEntity [
 
 	| mooseModel modelClass |
+	super followEntity: anEntity.
 	mooseModel := anEntity isMooseModel
 		              ifTrue: [ anEntity ]
 		              ifFalse: [ anEntity mooseModel ].

--- a/src/MooseIDE-NewTools/MiInspectorBrowser.class.st
+++ b/src/MooseIDE-NewTools/MiInspectorBrowser.class.st
@@ -93,6 +93,7 @@ MiInspectorBrowser >> canFollowEntity: anEntity [
 { #category : #actions }
 MiInspectorBrowser >> followEntity: anEntity [
 
+	super followEntity: anEntity.
 	anEntity ifNil: [ ^ self ].
 	self model entity: anEntity.
 	mainPresenter model: self model entity.

--- a/src/MooseIDE-QueriesBrowser/MiQueriesBrowser.class.st
+++ b/src/MooseIDE-QueriesBrowser/MiQueriesBrowser.class.st
@@ -70,12 +70,6 @@ MiQueriesBrowser class >> title [
 	^ 'Queries Browser'
 ]
 
-{ #category : #accessing }
-MiQueriesBrowser class >> titleForModelName: mooseModelName [
-
-	^ self title , ' (' , mooseModelName , ')'
-]
-
 { #category : #specs }
 MiQueriesBrowser class >> windowSize [
 
@@ -125,15 +119,14 @@ MiQueriesBrowser >> enableProgressNotification [
 MiQueriesBrowser >> followEntity: anEntity [
 
 	| busMooseEntities |
+	super followEntity: anEntity.
 	"Create a group in case that only one entity was received from the bus"
 	busMooseEntities := anEntity asMooseGroup allUsing: FamixTNamedEntity.
-		
+
 	"Create the new root query"
 	self resetRootQueryForEntities: busMooseEntities.
 
-	"Update window's title"
-	self window
-		title: (self class titleForModelName: busMooseEntities first mooseModel name).
+
 
 	"Update the all the sub presenters with this new query"
 	queriesListPresenter followNewEntity

--- a/src/MooseIDE-QueriesDashboard/MiQueriesDashboardBrowser.class.st
+++ b/src/MooseIDE-QueriesDashboard/MiQueriesDashboardBrowser.class.st
@@ -60,6 +60,7 @@ MiQueriesDashboardBrowser >> canFollowEntity: anObject [
 { #category : #actions }
 MiQueriesDashboardBrowser >> followEntity: anEntity [
 
+	super followEntity: anEntity.
 	specModel mooseModel: (anEntity isMooseModel
 			 ifTrue: [ anEntity ]
 			 ifFalse: [ anEntity mooseModel ]).

--- a/src/MooseIDE-Visualization/MiSystemComplexityBrowser.class.st
+++ b/src/MooseIDE-Visualization/MiSystemComplexityBrowser.class.st
@@ -87,8 +87,9 @@ MiSystemComplexityBrowser >> canTagEntities [
 MiSystemComplexityBrowser >> followEntity: aMooseGroup [
 
 	| newGroup |
+	super followEntity: aMooseGroup.
 	newGroup := aMooseGroup select: [ :e | e isClass ].
-	newGroup size < aMooseGroup size ifTrue: [ 
+	newGroup size < aMooseGroup size ifTrue: [
 		self inform:
 			(aMooseGroup size - newGroup size) asString , ' rejected entities.' ].
 	specModel entities: newGroup


### PR DESCRIPTION
update browsers by adding the name of the propagated model or  group.  Adding MiAbstractBrowser>>updateWindowTitleWith: and removing it in the subclasses when existing Updating MiAbstractBrowser>>followEntity: to call updateWindowTitleWith:  and calling super followEntity: anEntity  in the subclasses.