### PR TITLE
Optimize the way to compute commonProperties 

### DIFF
--- a/src/MooseIDE-Export/MiExportBrowser.class.st
+++ b/src/MooseIDE-Export/MiExportBrowser.class.st
@@ -167,11 +167,11 @@ MiExportBrowser >> commentsButton [
 { #category : #accessing }
 MiExportBrowser >> commonPropertiesIn: aMooseGroup [
 
-	| properties |
+	| properties mooseDescriptions |
 	aMooseGroup ifEmpty: [ ^ aMooseGroup ].
-
-	properties := ((aMooseGroup collect: [ :entity | 
-		                entity mooseDescription allPrimitiveProperties ]) 
+	mooseDescriptions := (aMooseGroup collect: [ :entity | 
+		                entity mooseDescription ]) asSet.
+	properties := ((mooseDescriptions collect: #allPrimitiveProperties)
 		               fold: [ :availableProperties :entityProperty | 
 			               availableProperties & entityProperty ]) sorted:
 		              #name ascending.


### PR DESCRIPTION
by first computing the set of the mooseDescriptions of the entities in the group as parameter. And then by computing the primitiveProperties for only this set.

Fix #1136