### PR TITLE
update the instance variable shapes inherited from RSBuilder in order…

### DIFF
--- a/src/MooseIDE-ButterflyMap/MiButterflyMapBuilder.class.st
+++ b/src/MooseIDE-ButterflyMap/MiButterflyMapBuilder.class.st
@@ -251,7 +251,7 @@ MiButterflyMapBuilder >> updateShapes [
 		allShapes addAll: layer.
 		rightLayout on: layer.
 		outgoingGroups add: layer ].
-
+	shapes := allShapes , { centralShape }.
 	self addInteractions: allShapes , { centralShape }.
 	self container addAll: allShapes , { centralShape }.
 	self container schildren: allShapes , { centralShape }.


### PR DESCRIPTION
… to enable the expand / collapse function.

usually, this is done in the renderIn: method.
fix #1144.