### PR TITLE
Fix EntityExporter column duplication

### DIFF
--- a/src/MooseIDE-Export/MiExportModel.class.st
+++ b/src/MooseIDE-Export/MiExportModel.class.st
@@ -35,19 +35,25 @@ Class {
 { #category : #'api - column property' }
 MiExportModel >> addColumnForProperty: aFM3Property [
 
-	self columnAdded:
-		(columns add:
-			 (MiExportPropertyColumnModel forProperty: aFM3Property))
+	| newQueryColumn |
+	
+	newQueryColumn := MiExportPropertyColumnModel forProperty:
+		                  aFM3Property.
+	(columns includes: newQueryColumn) ifTrue: [ ^ newQueryColumn ].
+	self columnAdded: (columns add: newQueryColumn)
 ]
 
 { #category : #'api - column script' }
 MiExportModel >> addColumnForQuery: aBlock withName: queryName [
 
-	| newColumn |
-	newColumn := columns add: (MiExportQueryColumnModel new
-			              query: aBlock;
-			              name: queryName;
-			              yourself).
+	| newColumn newQueryColumn |
+	
+	newQueryColumn := MiExportQueryColumnModel new
+		                  query: aBlock;
+		                  name: queryName;
+		                  yourself.
+	(columns includes: newQueryColumn) ifTrue: [ ^ newQueryColumn ].
+	newColumn := columns add: newQueryColumn.
 	self columnAdded: newColumn.
 	^ newColumn
 ]

--- a/src/MooseIDE-Export/MiExportPropertyColumnModel.class.st
+++ b/src/MooseIDE-Export/MiExportPropertyColumnModel.class.st
@@ -16,10 +16,32 @@ MiExportPropertyColumnModel class >> forProperty: aFM3Property [
 		  yourself
 ]
 
+{ #category : #comparing }
+MiExportPropertyColumnModel >> = anObject [
+	"Answer whether the receiver and anObject represent the same object."
+
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	^ property = anObject property and: [ name = anObject name1 ]
+]
+
+{ #category : #comparing }
+MiExportPropertyColumnModel >> hash [
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ property hash bitXor: name hash
+]
+
 { #category : #testing }
 MiExportPropertyColumnModel >> isPropertyColumn [
 
 	^ true
+]
+
+{ #category : #accessing }
+MiExportPropertyColumnModel >> name1 [
+
+	^ name
 ]
 
 { #category : #private }

--- a/src/MooseIDE-Export/MiExportQueryColumnModel.class.st
+++ b/src/MooseIDE-Export/MiExportQueryColumnModel.class.st
@@ -7,10 +7,32 @@ Class {
 	#category : #'MooseIDE-Export-Browser'
 }
 
+{ #category : #comparing }
+MiExportQueryColumnModel >> = anObject [
+	"Answer whether the receiver and anObject represent the same object."
+
+	self == anObject ifTrue: [ ^ true ].
+	self class = anObject class ifFalse: [ ^ false ].
+	^ name = anObject name1 and: [ query = anObject query ]
+]
+
+{ #category : #comparing }
+MiExportQueryColumnModel >> hash [
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ name hash bitXor: query hash
+]
+
 { #category : #testing }
 MiExportQueryColumnModel >> isQueryColumn [
 
 	^ true
+]
+
+{ #category : #accessing }
+MiExportQueryColumnModel >> name1 [
+
+	^ name
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- Add checks in MiExportModel>>addColumnForProperty:
- Add equality for Moose query columns (`MiExportQueryColumnModel`, and `MiExportPropertyColumnModel`)

Fix issue #1185