### PR TITLE
Add a library menu item to load Famix SQL - Not working yet

### DIFF
--- a/src/MooseIDE-Core/MooseLoadFamixSQLMenuCommand.class.st
+++ b/src/MooseIDE-Core/MooseLoadFamixSQLMenuCommand.class.st
@@ -1,0 +1,41 @@
+Class {
+	#name : #MooseLoadFamixSQLMenuCommand,
+	#superclass : #MooseAbstractLoadFamixMenuCommand,
+	#category : #'MooseIDE-Core-MenuBar'
+}
+
+{ #category : #accessing }
+MooseLoadFamixSQLMenuCommand class >> help [
+
+	^ 'Famix Metamodel for SQL'
+]
+
+{ #category : #accessing }
+MooseLoadFamixSQLMenuCommand class >> label [
+
+	^ 'Famix-SQL'
+]
+
+{ #category : #accessing }
+MooseLoadFamixSQLMenuCommand class >> menuPriority [
+
+	^super menuPriority + 1
+]
+
+{ #category : #accessing }
+MooseLoadFamixSQLMenuCommand >> baselineName [
+
+	^ 'FamixSQL'
+]
+
+{ #category : #accessing }
+MooseLoadFamixSQLMenuCommand >> repositoryURL [
+
+	^ 'github://moosetechnology/FamixSQL:' , self version , '/src'
+]
+
+{ #category : #accessing }
+MooseLoadFamixSQLMenuCommand >> version [
+
+	^ 'main'
+]


### PR DESCRIPTION
With @alesshosry 

Currently trying to load FamixSQL (https://github.com/moosetechnology/FamixSQL) will result in an error due to the refactoring of `WeakRegistry` class in a dependency (https://github.com/pharo-rdbms/Pharo-ODBC)

This can be bypassed by replacing the reference to `WeakRegistry` by `FinalizationRegistry` when loading it. 
There are two references to `WeakRegistry` in Pharo-ODBC:
- `ODBCConnection class>>#newConnections` that can be fixed at loading time and  
- `ODBCConnection>>#initializeStatements` that can be fixed after.
 
A pull request has been opened in Pharo-ODBC to fix it for the latest versions of Pharo and Moose (https://github.com/pharo-rdbms/Pharo-ODBC/pull/11). Once accepted, this feature should work and fix #1193 