### PR TITLE
Add menu to regenerate concrete MMs (reject tests MMs)

### DIFF
--- a/src/MooseIDE-Core/MooseRegenerateAllConcreteMetamodelsMenuCommand.class.st
+++ b/src/MooseIDE-Core/MooseRegenerateAllConcreteMetamodelsMenuCommand.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #MooseRegenerateAllConcreteMetamodelsMenuCommand,
+	#superclass : #MooseAbstractMetamodelMenuCommand,
+	#category : #'MooseIDE-Core-MenuBar'
+}
+
+{ #category : #accessing }
+MooseRegenerateAllConcreteMetamodelsMenuCommand class >> help [
+
+	^ 'Does the same as "regenerate all metamodels" but excluding generators that are in a package with "Test" in the name.'
+]
+
+{ #category : #accessing }
+MooseRegenerateAllConcreteMetamodelsMenuCommand class >> label [
+
+	^ 'Regenerate all concrete metamodels'
+]
+
+{ #category : #'world menu' }
+MooseRegenerateAllConcreteMetamodelsMenuCommand class >> menuCommandOn: aBuilder [
+
+	<worldMenu>
+	^ self menuCommandOn: aBuilder forCommand: self
+]
+
+{ #category : #accessing }
+MooseRegenerateAllConcreteMetamodelsMenuCommand class >> menuPriority [
+
+	^ super menuPriority + 1.5
+]
+
+{ #category : #executing }
+MooseRegenerateAllConcreteMetamodelsMenuCommand >> execute [
+
+	FamixMetamodelGenerator generateAllMetamodelsSuchAs: [ :generator | (generator package name includesSubstring: 'Test') not ]
+]


### PR DESCRIPTION
I often need to regenerate MMs but we have a lot of tests MM and it can take some times. I'm adding a command to regenerate only concrete MMs and not the tests ones