### PR TITLE
Remove dependency to STONCustomier that was not needed.

### DIFF
--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -69,7 +69,7 @@ BaselineOfMooseIDE >> defineGroups: spec [
 BaselineOfMooseIDE >> defineMooseCriticsPackages: spec [
 
 	spec
-		package: 'MooseIDE-CriticBrowser' with: [ spec requires: #( 'MooseIDE-Core' 'Famix-CriticBrowser-Entities' 'STONCustomizer' ) ];
+		package: 'MooseIDE-CriticBrowser' with: [ spec requires: #( 'MooseIDE-Core' 'Famix-CriticBrowser-Entities' ) ];
 		package: 'MooseIDE-CriticBrowser-Tests' with: [ spec requires: #( 'MooseIDE-Tests' 'MooseIDE-CriticBrowser' ) ];
 		
 		package: 'Famix-CriticBrowser-ManualEntities' with: [ spec requires: #( 'FamixQueries' ) ];
@@ -307,13 +307,4 @@ BaselineOfMooseIDE >> roassalExporters: spec [
 		baseline: 'RoassalExporters'
 		with: [ 
 		spec repository: 'github://pharo-graphics/RoassalExporters:v1.01/src' ]
-]
-
-{ #category : 'dependencies' }
-BaselineOfMooseIDE >> stonCustomizer: spec [
-
-	spec
-		baseline: 'STONCustomizer'
-		with: [ 
-		spec repository: 'github://jecisc/STONCustomizer:v1.x.x/src' ]
 ]

--- a/src/MooseIDE-CriticBrowser/MiCriticBrowser.class.st
+++ b/src/MooseIDE-CriticBrowser/MiCriticBrowser.class.st
@@ -198,8 +198,8 @@ MiCriticBrowser >> exportRules [
 MiCriticBrowser >> exportRulesToStream: aStream [
 
 	specModel ruleComponents do: [ :el |
-		SCExporter export: el onStream: aStream ].
-	SCExporter export: specModel createHierarchyTree onStream: aStream
+		(STONWriter on: aStream) nextPut: el ].
+	(STONWriter on: aStream) nextPut: specModel createHierarchyTree
 ]
 
 { #category : 'actions' }


### PR DESCRIPTION
In the process of removing Roassal from the baseline and use system version