### PR TITLE
Remove Roassal from the baseline

### DIFF
--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -44,7 +44,6 @@ BaselineOfMooseIDE >> customProjectAttributes [
 BaselineOfMooseIDE >> defineDependencies: spec [
 
 	self labelContractor: spec.
-	self roassal: spec.
 	self roassalExporters: spec.
 	self hierarchicalVisualizations: spec.
 	self pharoAIHierachicalClustering: spec.
@@ -91,26 +90,25 @@ BaselineOfMooseIDE >> defineMooseDependencies: spec [
 BaselineOfMooseIDE >> definePackages: spec [
 
 	spec
-		package: 'MooseIDE-Core' with: [
-			spec requires:
-					#( 'LabelContractor' 'RoassalExporters' ) ];
+		package: 'MooseIDE-Core'
+		with: [ spec requires: #( 'LabelContractor' 'RoassalExporters' ) ];
 		package: 'MooseIDE-Visualization'
 		with: [
 			spec requires: #( 'MooseIDE-Core' 'HierarchicalVisualizations' ) ];
 		package: 'MooseIDE-Meta'
 		with: [ spec requires: #( 'MooseIDE-Core' 'MooseIDE-Famix' ) ];
 		package: 'MooseIDE-Dependency' with: [
-			spec requires:
-					#( 'MooseIDE-Core' 'MooseIDE-Visualization'
-					   'Roassal' 'AIHierarchicalClustering' ) ];
+				spec requires:
+						#( 'MooseIDE-Core' 'MooseIDE-Visualization'
+						   'AIHierarchicalClustering' ) ];
 		package: 'MooseIDE-Tests' with: [
-			spec requires:
-					#( 'MooseIDE-Core' 'MooseIDE-Dependency' 'MooseIDE-Visualization' ) ];
+				spec requires:
+						#( 'MooseIDE-Core' 'MooseIDE-Dependency' 'MooseIDE-Visualization' ) ];
 		package: 'MooseIDE-AttributedText';
 		package: 'MooseIDE-Famix' with: [
-			spec requires:
-					#( 'MooseIDE-Core' 'MooseIDE-Visualization'
-					   'MooseIDE-AttributedText' ) ];
+				spec requires:
+						#( 'MooseIDE-Core' 'MooseIDE-Visualization'
+						   'MooseIDE-AttributedText' ) ];
 		package: 'MooseIDE-QueriesBrowser'
 		with: [ spec requires: #( 'MooseIDE-Core' 'FamixQueries' ) ];
 		package: 'MooseIDE-QueriesBrowser-Tests'
@@ -145,9 +143,9 @@ BaselineOfMooseIDE >> definePackages: spec [
 		package: 'MooseIDE-QueriesDashboard'
 		with: [ spec requires: #( 'MooseIDE-Core' ) ];
 		package: 'MooseIDE-LayerVisualization' with: [
-			spec requires:
-					#( 'MooseIDE-Core' 'MooseIDE-Visualization'
-					   'MooseIDE-QueriesDashboard' ) ];
+				spec requires:
+						#( 'MooseIDE-Core' 'MooseIDE-Visualization'
+						   'MooseIDE-QueriesDashboard' ) ];
 		package: 'MooseIDE-ClassBlueprint'
 		with: [
 			spec requires: #( 'MooseIDE-Visualization' 'ClassBlueprint' ) ];
@@ -288,15 +286,6 @@ BaselineOfMooseIDE >> removeRoassalFromSystem [
 			            select: [ :each |
 			            (string surroundedBy: '*') match: each name ]
 			            thenDo: [ :each | each removeFromSystem ] ]
-]
-
-{ #category : 'dependencies' }
-BaselineOfMooseIDE >> roassal: spec [
-
-	spec
-		baseline: 'Roassal'
-		with: [
-		spec repository: 'github://pharo-graphics/Roassal:v1.06c/src' ]
 ]
 
 { #category : 'dependencies' }

--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -281,5 +281,5 @@ BaselineOfMooseIDE >> roassalExporters: spec [
 	spec
 		baseline: 'RoassalExporters'
 		with: [ 
-		spec repository: 'github://pharo-graphics/RoassalExporters:v1.01/src' ]
+		spec repository: 'github://pharo-graphics/RoassalExporters:v1.02/src' ]
 ]

--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -10,17 +10,15 @@ BaselineOfMooseIDE >> baseline: spec [
 
 	<baseline>
 	spec for: #common do: [
-		spec preLoadDoIt: #removeRoassalFromSystem.
+			self defineDependencies: spec.
+			self definePackages: spec.
+			self defineGroups: spec.
 
-		self defineDependencies: spec.
-		self definePackages: spec.
-		self defineGroups: spec.
+			spec for: #NoFamix do: [
+					self defineMooseDependencies: spec.
+					self definePackagesWhenNoFamix: spec ].
 
-		spec for: #NoFamix do: [
-			self defineMooseDependencies: spec.
-			self definePackagesWhenNoFamix: spec ].
-
-		spec postLoadDoIt: #registerCustomTools ]
+			spec postLoadDoIt: #registerCustomTools ]
 ]
 
 { #category : 'dependencies' }
@@ -275,17 +273,6 @@ BaselineOfMooseIDE >> registerShortcuts [
 	(Smalltalk classNamed: #MiShortcutsCategory) ifNotNil: [
 		:miShortcutsCategory |
 		miShortcutsCategory new installAsGlobalCategory ]
-]
-
-{ #category : 'actions' }
-BaselineOfMooseIDE >> removeRoassalFromSystem [
-
-	#( Roassal3 Numeric ) do: [ :string |
-		| packages |
-		packages := self packageOrganizer packages
-			            select: [ :each |
-			            (string surroundedBy: '*') match: each name ]
-			            thenDo: [ :each | each removeFromSystem ] ]
 ]
 
 { #category : 'dependencies' }


### PR DESCRIPTION
We cannot stay on an old tag forever.
Roassal has some issues that have been fixed in P13, namely the inspector tabs, and things like this will continue to happen.
We need to use the Pharo version.