### PR TITLE
Fix propagation of entities in the QueryBrowser

### DIFF
--- a/src/MooseIDE-QueriesBrowser/MiQueriesBrowser.class.st
+++ b/src/MooseIDE-QueriesBrowser/MiQueriesBrowser.class.st
@@ -88,8 +88,7 @@ MiQueriesBrowser >> browserClosed [
 { #category : 'testing' }
 MiQueriesBrowser >> canFollowEntity: anObject [
 
-	^ anObject isMooseObject and: [ 
-		  (anObject asMooseGroup select: #isQueryable ) isNotEmpty ]
+	^ anObject isMooseObject and: [ anObject asMooseGroup anySatisfy: #isQueryable ]
 ]
 
 { #category : 'testing' }
@@ -124,7 +123,7 @@ MiQueriesBrowser >> followEntity: anEntity [
 	| busMooseEntities |
 	super followEntity: anEntity.
 	"Create a group in case that only one entity was received from the bus"
-	busMooseEntities := anEntity asMooseGroup .
+	busMooseEntities := anEntity asMooseGroup select: #isQueryable.
 
 	"Create the new root query"
 	self resetRootQueryForEntities: busMooseEntities.


### PR DESCRIPTION
This changes two things:
- Optimize #canFollowEntity: to by faster on big models
- #followEntity: should select only queryable entities. Else we end up looking up the properties of every entity such as source anchors while initializing the list item presenters of the query browser