### PR TITLE
fix: moved tagDescriptionPage out of TagManagementPage

### DIFF
--- a/src/MooseIDE-Tagging-Tests/MiTagBrowserTest.class.st
+++ b/src/MooseIDE-Tagging-Tests/MiTagBrowserTest.class.st
@@ -44,7 +44,7 @@ MiTagBrowserTest >> receiveEntityToSelect [
 
 	browser refreshTagList.
 	browser tagManagementPage setTagTo: tag.
-	browser tagManagementPage descriptionPage addAll
+	browser descriptionPage addAll
 ]
 
 { #category : 'running' }

--- a/src/MooseIDE-Tagging-Tests/MiTagCreationFormTest.class.st
+++ b/src/MooseIDE-Tagging-Tests/MiTagCreationFormTest.class.st
@@ -20,11 +20,11 @@ MiTagCreationFormTest >> presenterOwner [
 	^ browser
 ]
 
-{ #category : 'initialization' }
+{ #category : 'running' }
 MiTagCreationFormTest >> setUp [
 
 	super setUp.
-	creationForm := browser openTagCreationForm.
+	creationForm := browser createTag
 ]
 
 { #category : 'running' }

--- a/src/MooseIDE-Tagging-Tests/MiTagExtentPageTest.class.st
+++ b/src/MooseIDE-Tagging-Tests/MiTagExtentPageTest.class.st
@@ -60,7 +60,7 @@ MiTagExtentPageTest >> testRefreshTaggedEntitiesList [
 	entity := browser specModel entities first.
 	browser followEntity: entity.
 	
-	self assert: (browser tagManagementPage descriptionPage) selectedItems size equals: 3.
+	self assert: (browser descriptionPage) selectedItems size equals: 3.
 
 	
 ]

--- a/src/MooseIDE-Tagging/MiTagBrowser.class.st
+++ b/src/MooseIDE-Tagging/MiTagBrowser.class.st
@@ -10,7 +10,11 @@ Class {
 	#name : 'MiTagBrowser',
 	#superclass : 'MiAbstractBrowser',
 	#instVars : [
-		'tagManagementPage'
+		'tagManagementPage',
+		'staticTagDescriptionPage',
+		'dynamicTagDescriptionPage',
+		'descriptionPage',
+		'separator'
 	],
 	#category : 'MooseIDE-Tagging-Browser',
 	#package : 'MooseIDE-Tagging',
@@ -109,10 +113,41 @@ MiTagBrowser >> consume: anObject [
 			ifTrue: [ tagManagementPage refreshTaggedEntitiesList ] ]
 ]
 
+{ #category : 'initialization' }
+MiTagBrowser >> createTag [
+	"returning the MiTagCreationForm allows to test it"
+
+	^MiTagCreationForm new 
+		tagBrowser: self ;
+		open ;
+		yourself
+]
+
 { #category : 'accessing' }
 MiTagBrowser >> descriptionPage [
 
-	^ tagManagementPage descriptionPage
+	^descriptionPage
+]
+
+{ #category : 'initialization' }
+MiTagBrowser >> editCurrentTag [
+	"returning the MiTagCreationForm allows to test it"
+
+	^MiTagEditionForm new 
+		tagBrowser: self ;
+		open ;
+		yourself
+]
+
+{ #category : 'initialization' }
+MiTagBrowser >> editTag: aTag [
+	"returning the MiTagCreationForm allows to test it"
+
+	^MiTagEditionForm new 
+		tagBrowser: self ;
+		fillFormWithTag: aTag ;
+		open ;
+		yourself
 ]
 
 { #category : 'actions' }
@@ -122,6 +157,12 @@ MiTagBrowser >> followEntity: anEntity [
 	specModel mooseModel
 		ifNil: [ self showNoMooseModel ].
 	tagManagementPage refresh
+]
+
+{ #category : 'refreshing' }
+MiTagBrowser >> hideDescriptionPage [
+
+	descriptionPage hide
 ]
 
 { #category : 'initialization' }
@@ -137,8 +178,16 @@ MiTagBrowser >> initialize [
 { #category : 'initialization' }
 MiTagBrowser >> initializeLayout [
 
-	self layout: (SpScrollableLayout with: tagManagementPage).
-	"At start browser has no moose model"
+	| sep |
+	sep := self separator.
+
+	self layout: (SpBoxLayout newLeftToRight
+			 spacing: 4;
+			 add: tagManagementPage width: 200;
+			 add: sep width: 2;
+			 add: descriptionPage;
+			 yourself).
+
 	self showNoMooseModel
 	
 ]
@@ -146,7 +195,19 @@ MiTagBrowser >> initializeLayout [
 { #category : 'initialization' }
 MiTagBrowser >> initializePresenters [
 
+	separator := SpRoassalPresenter new.
+	separator canvas
+		color: (Color
+			r: 40
+			g: 40
+			b: 40
+			range: 255) translucent.
+
 	tagManagementPage := MiTagManagementPage newApplication: self application owner: self model: specModel.
+
+	staticTagDescriptionPage := self instantiate: MiTagExtentPage.
+	dynamicTagDescriptionPage := self instantiate: MiTagIntentPage.
+	descriptionPage := staticTagDescriptionPage.
 
 	self initializeLayout
 ]
@@ -172,29 +233,21 @@ MiTagBrowser >> newTagSelected [
 ]
 
 { #category : 'initialization' }
-MiTagBrowser >> openTagCreationForm [
-	"returning the MiTagCreationForm allows to test it"
+MiTagBrowser >> preparePageFor: aTag [
 
-	^MiTagCreationForm new 
-		tagBrowser: self ;
-		open ;
-		yourself
-]
-
-{ #category : 'initialization' }
-MiTagBrowser >> openTagEditionForm [
-	"returning the MiTagCreationForm allows to test it"
-
-	^MiTagEditionForm new 
-		tagBrowser: self ;
-		open ;
-		yourself
+	aTag isIntent ifTrue: [ 
+		self layout replace: descriptionPage with: dynamicTagDescriptionPage.
+		descriptionPage := dynamicTagDescriptionPage.
+		^ self ].
+	self layout replace: descriptionPage with: staticTagDescriptionPage.
+	descriptionPage := staticTagDescriptionPage
 ]
 
 { #category : 'accessing' }
 MiTagBrowser >> refreshDescriptionPage [
 
-	tagManagementPage refreshDescriptionPage
+	self setRightPart: descriptionPage.
+	descriptionPage refresh
 ]
 
 { #category : 'refreshing' }
@@ -206,20 +259,57 @@ MiTagBrowser >> refreshTagList [
 { #category : 'testing' }
 MiTagBrowser >> remove: aTagAssociation [
 
-	tagManagementPage refreshTaggedEntitiesList 
+]
+
+{ #category : 'accessing' }
+MiTagBrowser >> selectedItems [
+
+	^ staticTagDescriptionPage selectedItems
+]
+
+{ #category : 'accessing' }
+MiTagBrowser >> separator [
+
+	^separator 
+]
+
+{ #category : 'initialization' }
+MiTagBrowser >> setRightPart: aSpPresenter [
+	"We need to replace the right part of the window (descriptionPage) with the new presenter
+	 This part is the 3rd presenter in the layout
+	 So if this right part is not the same as aSpPresenter, we remove it and then add the correct one"
+
+	(layout presenters third = aSpPresenter) ifTrue: [ ^self ].
+
+	layout remove: layout presenters third.
+	layout add: aSpPresenter 
+
 ]
 
 { #category : 'initialization' }
 MiTagBrowser >> setTagTo: aTag [
 
 	self specModel currentTag: aTag.
+
+	self preparePageFor: aTag.
+	descriptionPage setTag: aTag.
+	descriptionPage show.
+
+	self refreshDescriptionPage.
 	self updateToolbar
 ]
 
 { #category : 'initialization' }
 MiTagBrowser >> showNoMooseModel [
 
-	tagManagementPage showNoMooseModel 
+	self setRightPart: (SpPresenter new
+		layout: (SpBoxLayout newTopToBottom
+			vAlignCenter;
+			hAlignCenter;
+			add: 'No available moose model in selected buses.';
+			add: 'Propagate entities or moose model on selected buses.';
+			yourself);
+		yourself)
 ]
 
 { #category : 'accessing' }

--- a/src/MooseIDE-Tagging/MiTagBrowserModel.class.st
+++ b/src/MooseIDE-Tagging/MiTagBrowserModel.class.st
@@ -122,9 +122,14 @@ MiTagBrowserModel >> deleteCurrentTag [
 
 	| tag |
 	tag := currentTag.
+
+	MiApplication current removeItem: tag.
+	browser hideDescriptionPage.
+
 	tag isIntent ifTrue: [ 
 		dynamicTags remove: tag.
-		^ tag ]. tag remove.
+		^ tag ].
+	tag remove.
 	tag categories ifNotEmpty: [ tag categories first removeTag: tag ].
 	self currentTag: nil.
 	^ tag
@@ -153,6 +158,17 @@ MiTagBrowserModel >> editCurrentDynamicTag: name description: description color:
 		category: category.
 	tag query: query.
 
+	browser refreshTagList.
+	browser refreshDescriptionPage.
+	self currentApplication updateItem: tag
+]
+
+{ #category : 'actions' }
+MiTagBrowserModel >> editCurrentTag [
+
+	| tag |
+	tag := self currentTag.
+	browser editTag: tag.
 	browser refreshTagList.
 	browser refreshDescriptionPage.
 	self currentApplication updateItem: tag
@@ -190,7 +206,11 @@ MiTagBrowserModel >> entities [
 { #category : 'accessing' }
 MiTagBrowserModel >> entities: anObject [
 
-	entities := anObject
+	entities := anObject.
+	self mooseModel
+		ifNil: [ browser showNoMooseModel ]
+		ifNotNil: [ browser refreshDescriptionPage ].
+	browser tagManagementPage refresh
 ]
 
 { #category : 'accessing' }
@@ -244,6 +264,12 @@ MiTagBrowserModel >> setTag: newTag description: aText color: aColor category: a
 	aCategory ifNotNil: [
 		aCategory addTag: newTag.
 		newTag addCategory: aCategory ]
+]
+
+{ #category : 'initialization' }
+MiTagBrowserModel >> setTagTo: aTag [
+
+	browser setTagTo: aTag.
 ]
 
 { #category : 'accessing' }

--- a/src/MooseIDE-Tagging/MiTagEditionForm.class.st
+++ b/src/MooseIDE-Tagging/MiTagEditionForm.class.st
@@ -156,14 +156,6 @@ MiTagEditionForm >> submit [
 ]
 
 { #category : 'accessing' }
-MiTagEditionForm >> tagBrowser: aTagBrowser [
-
-	super tagBrowser: aTagBrowser.
-
-	self fillFormWithTag: self specModel currentTag
-]
-
-{ #category : 'accessing' }
 MiTagEditionForm >> title [
 
 	^ 'Edit tag'

--- a/src/MooseIDE-Tagging/MiTagManagementPage.class.st
+++ b/src/MooseIDE-Tagging/MiTagManagementPage.class.st
@@ -7,10 +7,7 @@ Class {
 	#instVars : [
 		'categoryManagement',
 		'tagList',
-		'descriptionPage',
 		'tagModel',
-		'tagDescriptionPage',
-		'dynamicTagDescriptionPage',
 		'addTagButton',
 		'btnIsExtent',
 		'btnIsIntent'
@@ -73,29 +70,14 @@ MiTagManagementPage >> connectPresenters [
 { #category : 'action' }
 MiTagManagementPage >> deleteCurrentTag [
 
-	|tag|
-	tag := tagModel deleteCurrentTag.
-	self owner application removeItem: tag.
-	descriptionPage hide.
+	tagModel deleteCurrentTag.
 	self refreshTagList
-]
-
-{ #category : 'accessing' }
-MiTagManagementPage >> descriptionPage [
-
-	^ descriptionPage
-]
-
-{ #category : 'accessing' }
-MiTagManagementPage >> dynamicTagDescriptionPage [
-
-	^ dynamicTagDescriptionPage
 ]
 
 { #category : 'action' }
 MiTagManagementPage >> editCurrentTag [
 
-	self owner openTagEditionForm
+	tagModel editCurrentTag
 ]
 
 { #category : 'accessing' }
@@ -108,60 +90,43 @@ MiTagManagementPage >> extentTagButton [
 MiTagManagementPage >> initializeLayout [
 
 	| sep |
-	(sep := SpRoassalPresenter new) canvas color: (Color
-			 r: 40
-			 g: 40
-			 b: 40
-			 range: 255) translucent.
+	sep := owner separator.
 
-	self layout: (SpBoxLayout newLeftToRight
-			 spacing: 4;
-			 add: (SpBoxLayout newTopToBottom
-					  spacing: 5;
-					  add: categoryManagement expand: false;
-					  add: (SpBoxLayout newLeftToRight
-							   add: 'Tag list' asPresenter;
-							   hAlignCenter;
-							   yourself)
-					  expand: false;
-					  add: (SpBoxLayout newLeftToRight
-							   spacing: 3;
-							   add: btnIsExtent;
-							   add: btnIsIntent;
-							   add: addTagButton width: 30;
-							   yourself)
-					  expand: false;
-					  add: tagList;
-					  yourself)
-			 width: 200;
-			 add: sep width: 2;
-			 add: descriptionPage;
-			 yourself)
+	self layout: (SpBoxLayout newTopToBottom
+		spacing: 5;
+		add: categoryManagement expand: false;
+		add: (SpBoxLayout newLeftToRight
+			add: 'Tag list' asPresenter;
+			hAlignCenter;
+			yourself)
+		expand: false;
+		add: (SpBoxLayout newLeftToRight
+			spacing: 3;
+			add: btnIsExtent;
+			add: btnIsIntent;
+			add: addTagButton width: 30;
+			yourself)
+		expand: false;
+		add: tagList;
+		yourself).
+
 ]
 
 { #category : 'initialization' }
 MiTagManagementPage >> initializePresenters [
 
-	categoryManagement := self
-		                      instantiate: MiTagCategoriesPresenter
-		                      on: tagModel.
-
-	tagDescriptionPage := self instantiate: MiTagExtentPage.
-	dynamicTagDescriptionPage := self instantiate: MiTagIntentPage.
-	descriptionPage := tagDescriptionPage.
+	categoryManagement := self instantiate: MiTagCategoriesPresenter on: tagModel.
 
 	btnIsExtent := self newToggleButton
-		               state: true;
-		               icon:
-			               (Smalltalk ui icons iconNamed: #checkboxSelected);
-		               label: 'Static';
-		               yourself.
+		state: true;
+		icon: (Smalltalk ui icons iconNamed: #checkboxSelected);
+		label: 'Static';
+		yourself.
 	btnIsIntent := self newToggleButton
-		               state: false;
-		               icon:
-			               (Smalltalk ui icons iconNamed: #checkboxUnselected);
-		               label: 'Dynamic';
-		               yourself.
+		state: false;
+		icon: (Smalltalk ui icons iconNamed: #checkboxUnselected);
+		label: 'Dynamic';
+		yourself.
 
 	tagList := self newList.
 	tagList contextMenu: self tagListMenu.
@@ -171,7 +136,7 @@ MiTagManagementPage >> initializePresenters [
 		whenSelectionChangedDo: [ :selection |
 			selection selectedItem ifNotNil: [ :item | self setTagTo: item ] ].
 	addTagButton := self newButton icon: (Smalltalk iconNamed: #smallAdd).
-	addTagButton action: [ self owner openTagCreationForm ].
+	addTagButton action: [ self owner createTag ].
 
 	self initializeLayout
 ]
@@ -191,36 +156,17 @@ MiTagManagementPage >> model [
 	^ self specModel
 ]
 
-{ #category : 'action' }
-MiTagManagementPage >> preparePageFor: aTag [
-
-	aTag isIntent ifTrue: [ 
-		self layout replace: descriptionPage with: dynamicTagDescriptionPage.
-		descriptionPage := dynamicTagDescriptionPage.
-		^ self ].
-	self layout replace: descriptionPage with: tagDescriptionPage.
-	descriptionPage := tagDescriptionPage
-]
-
 { #category : 'refreshing' }
 MiTagManagementPage >> refresh [
 
 	self refreshTagList.
-	self refreshCategoryList.
-	self refreshDescriptionPage
+	self refreshCategoryList
 ]
 
 { #category : 'refreshing' }
 MiTagManagementPage >> refreshCategoryList [
 
 	categoryManagement refreshCategoryList
-]
-
-{ #category : 'refreshing' }
-MiTagManagementPage >> refreshDescriptionPage [
-
-	self setRightPart: descriptionPage.
-	descriptionPage refresh
 ]
 
 { #category : 'refreshing' }
@@ -233,23 +179,11 @@ MiTagManagementPage >> refreshTagList [
 		tagList selectItem: currentTag ]
 ]
 
-{ #category : 'initialization' }
-MiTagManagementPage >> refreshTaggedEntitiesList [
-
-	descriptionPage refreshTaggedEntitiesList
-]
-
 { #category : 'action' }
 MiTagManagementPage >> removeCategory [
 
 	self specModel deleteCurrentCategory.
 	self refreshCategoryList
-]
-
-{ #category : 'accessing' }
-MiTagManagementPage >> selectedItems [
-
-	^ tagDescriptionPage selectedItems
 ]
 
 { #category : 'initialization' }
@@ -266,43 +200,11 @@ MiTagManagementPage >> setModelBeforeInitialization: aTagModel [
 	tagModel := aTagModel
 ]
 
-{ #category : 'initialization' }
-MiTagManagementPage >> setRightPart: aSpPresenter [
-	"temporary hack, the descriptionPage should not be in this class but in the MiTagBrowser
-	 We need to replace the right part of the window (descriptionPage) with the new presenter
-	 this part is the 3rd presenter in the layout
-	 So if this right part is not the same as aSpPresenter,
-	 we remove it and then add the correct one"
-
-	(layout presenters third = aSpPresenter) ifTrue: [ ^self ].
-
-	layout remove: layout presenters third.
-	layout add: aSpPresenter 
-
-]
-
 { #category : 'action' }
 MiTagManagementPage >> setTagTo: aTag [
 
-	self owner setTagTo: aTag.
-	self preparePageFor: aTag.
-	descriptionPage setTag: aTag.
-	descriptionPage show.
-	self refreshDescriptionPage.
-	self update
-]
+	self specModel setTagTo: aTag.
 
-{ #category : 'initialization' }
-MiTagManagementPage >> showNoMooseModel [
-
-	self setRightPart: (SpPresenter new
-		layout: (SpBoxLayout newTopToBottom
-			vAlignCenter;
-			hAlignCenter;
-			add: 'No available moose model in selected buses.';
-			add: 'Propagate entities or moose model on selected buses.';
-			yourself);
-		yourself)
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
Large refactor:
moved tagDescriptionPage out of TagManagementPage into TagBrowser.
Straightened a bit the all interaction model.
Fixed tests

fix #1437 