### PR TITLE
Add GitHub importer

### DIFF
--- a/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
+++ b/src/BaselineOfMooseIDE/BaselineOfMooseIDE.class.st
@@ -98,7 +98,7 @@ BaselineOfMooseIDE >> definePackages: spec [
 		package: 'MooseIDE-ArchitecturalMap' with: [ spec requires: #( 'MooseIDE-Visualization' ) ];
 		package: 'MooseIDE-ArchitecturalMap-Tests' with: [ spec requires: #( 'MooseIDE-ArchitecturalMap' 'MooseIDE-Tests' ) ];
 		package: 'MooseIDE-DeadCode' with: [ spec requires: #( 'MooseIDE-Core' ) ];
-		package: 'MooseIDE-DeadCode-Tests' with: [ spec requires: #( 'MooseIDE-DeadCode' 'MooseIDE-Tests' ) ];		
+		package: 'MooseIDE-DeadCode-Tests' with: [ spec requires: #( 'MooseIDE-DeadCode' 'MooseIDE-Tests' ) ];
 		package: 'MooseIDE-DSM' with: [ spec requires: #( 'MooseIDE-Visualization' 'AIHierarchicalClustering' ) ];
 		package: 'MooseIDE-DistributionMap' with: [ spec requires: #( 'MooseIDE-Visualization' 'AIHierarchicalClustering' ) ];
 		package: 'MooseIDE-HeatMap' with: [ spec requires: #( 'MooseIDE-Visualization' ) ];
@@ -124,7 +124,9 @@ BaselineOfMooseIDE >> definePackages: spec [
 		package: 'MooseIDE-Spotter';
 		package: 'MooseIDE-Core-Reporter' with: [ spec requires: #( 'MooseIDE-Core' ) ];
 		package: 'MooseIDE-Spotter-Tests' with: [ spec requires: #( 'MooseIDE-Spotter' ) ];
-		package: 'MooseIDE-BulkEditor'.
+		package: 'MooseIDE-BulkEditor';
+		package: 'MooseIDE-Github-Importer' with: [ spec requires: #( 'MooseIDE-Meta' ) ];
+		package: 'MooseIDE-Github-Importer-Tests' with: [ spec requires: #( 'MooseIDE-Github-Importer' ) ].
 
 	self defineMooseCriticsPackages: spec
 ]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubImportPresenterStub.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubImportPresenterStub.class.st
@@ -1,0 +1,31 @@
+"
+I am a MiGithubImportPresenter whose privateImportModel answers canned models without downloading anything, to test the import flow of the dialog.
+"
+Class {
+	#name : 'MiGithubImportPresenterStub',
+	#superclass : 'MiGithubImportPresenter',
+	#instVars : [
+		'importedModels'
+	],
+	#category : 'MooseIDE-Github-Importer-Tests-Tests',
+	#package : 'MooseIDE-Github-Importer-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'accessing' }
+MiGithubImportPresenterStub >> importedModels [
+
+	^ importedModels
+]
+
+{ #category : 'accessing' }
+MiGithubImportPresenterStub >> importedModels: aCollection [
+
+	importedModels := aCollection
+]
+
+{ #category : 'action' }
+MiGithubImportPresenterStub >> privateImportModel [
+
+	^ MiMooseModelsWrapper models: importedModels
+]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubImportPresenterTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubImportPresenterTest.class.st
@@ -1,0 +1,36 @@
+"
+I test the import flow of MiGithubImportPresenter with a stubbed privateImportModel: the imported models are checked not to be empty and are answered in a MiMooseModelsWrapper.
+"
+Class {
+	#name : 'MiGithubImportPresenterTest',
+	#superclass : 'TestCase',
+	#category : 'MooseIDE-Github-Importer-Tests-Tests',
+	#package : 'MooseIDE-Github-Importer-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+MiGithubImportPresenterTest >> testImportModelWithEmptyModel [
+
+	| presenter |
+	presenter := MiGithubImportPresenterStub new
+		             importedModels: { FamixStModel new };
+		             yourself.
+
+	self should: [ presenter importModel ] raise: Error
+]
+
+{ #category : 'tests' }
+MiGithubImportPresenterTest >> testImportModelWithModels [
+
+	| presenter modelsWrapper model |
+	model := FamixStModel new.
+	model newClassNamed: 'AClass'.
+	presenter := MiGithubImportPresenterStub new
+		             importedModels: { model };
+		             yourself.
+	modelsWrapper := presenter importModel.
+
+	self assert: modelsWrapper models size equals: 1.
+	self assert: modelsWrapper models anyOne size equals: 1
+]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
@@ -21,3 +21,18 @@ MiGithubImporterTest >> testFolderForVersion [
 
 	self assert: downloadedFolder equals: expectedFolder
 ]
+
+{ #category : 'tests' }
+MiGithubImporterTest >> testModelNameFromFolder [
+
+	| repository importer |
+	repository := MiGithubRepositoryStub owner: 'INRIA' projectName: 'VerveineJ'.
+	importer := MiGithubImporter new
+		            repository: repository;
+		            versions: OrderedCollection new;
+		            yourself.
+
+	self assert: (importer modelNameFromFolder: 'v5' asFileReference) equals: 'VerveineJ-v5'.
+	self assert: (importer modelNameFromFolder: 'v1.0.0' asFileReference) equals: 'VerveineJ-v1-0-0'.
+	self assert: (importer modelNameFromFolder: 'PR-42' asFileReference) equals: 'VerveineJ-PR-42'
+]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
@@ -33,6 +33,6 @@ MiGithubImporterTest >> testModelNameFromFolder [
 		            yourself.
 
 	self assert: (importer modelNameFromFolder: 'v5' asFileReference) equals: 'VerveineJ-v5'.
-	self assert: (importer modelNameFromFolder: 'v1.0.0' asFileReference) equals: 'VerveineJ-v1-0-0'.
+	self assert: (importer modelNameFromFolder: 'v1.0.0' asFileReference) equals: 'VerveineJ-v1.0.0'.
 	self assert: (importer modelNameFromFolder: 'PR-42' asFileReference) equals: 'VerveineJ-PR-42'
 ]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
@@ -17,7 +17,7 @@ MiGithubImporterTest >> testFolderForVersion [
 		            repository: (MiGithubRepository owner: 'moosetechnology' projectName: 'MooseIDE');
 		            yourself.
 	downloadedFolder := importer folderForVersion: (MiGithubVersion tagNamed: 'v1.0').
-	expectedFolder := FileLocator imageDirectory / 'github-moose-cache' / 'MooseIDE' / 'v1.0'.
+	expectedFolder := FileLocator localDirectory / 'github-moose-cache' / 'MooseIDE' / 'v1.0'.
 
 	self assert: downloadedFolder equals: expectedFolder
 ]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
@@ -1,0 +1,33 @@
+"
+I test MiGithubImporter: the language support policy and the layout of the cache directory. I never access the network.
+"
+Class {
+	#name : 'MiGithubImporterTest',
+	#superclass : 'TestCase',
+	#category : 'MooseIDE-Github-Importer-Tests-Tests',
+	#package : 'MooseIDE-Github-Importer-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+MiGithubImporterTest >> testFolderForVersion [
+
+	| repository importer downloadedFolder expectedFolder |
+	repository := MiGithubRepositoryStub owner: 'moosetechnology' projectName: 'MooseIDE'.
+	importer := MiGithubImporter new
+		            repository: repository;
+		            versions: OrderedCollection new;
+		            yourself.
+	downloadedFolder := importer folderForVersion: (MiGithubVersion tagNamed: 'v1.0').
+	expectedFolder := FileLocator imageDirectory / 'github-moose-cache' / 'MooseIDE' / 'v1.0'.
+
+	self assert: downloadedFolder fullName equals: expectedFolder fullName
+]
+
+{ #category : 'tests' }
+MiGithubImporterTest >> testIsLanguageSupported [
+
+	self assert: (MiGithubImporter isLanguageSupported: 'Java').
+	self deny: (MiGithubImporter isLanguageSupported: 'Python').
+	self deny: (MiGithubImporter isLanguageSupported: nil)
+]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubImporterTest.class.st
@@ -12,22 +12,12 @@ Class {
 { #category : 'tests' }
 MiGithubImporterTest >> testFolderForVersion [
 
-	| repository importer downloadedFolder expectedFolder |
-	repository := MiGithubRepositoryStub owner: 'moosetechnology' projectName: 'MooseIDE'.
+	| importer downloadedFolder expectedFolder |
 	importer := MiGithubImporter new
-		            repository: repository;
-		            versions: OrderedCollection new;
+		            repository: (MiGithubRepository owner: 'moosetechnology' projectName: 'MooseIDE');
 		            yourself.
 	downloadedFolder := importer folderForVersion: (MiGithubVersion tagNamed: 'v1.0').
 	expectedFolder := FileLocator imageDirectory / 'github-moose-cache' / 'MooseIDE' / 'v1.0'.
 
-	self assert: downloadedFolder fullName equals: expectedFolder fullName
-]
-
-{ #category : 'tests' }
-MiGithubImporterTest >> testIsLanguageSupported [
-
-	self assert: (MiGithubImporter isLanguageSupported: 'Java').
-	self deny: (MiGithubImporter isLanguageSupported: 'Python').
-	self deny: (MiGithubImporter isLanguageSupported: nil)
+	self assert: downloadedFolder equals: expectedFolder
 ]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubRepositoryStub.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubRepositoryStub.class.st
@@ -1,0 +1,49 @@
+"
+I am a MiGithubRepository that answers canned responses instead of querying the Github API, to test the Github importer without network. I map query paths to answers with #at:put:.
+"
+Class {
+	#name : 'MiGithubRepositoryStub',
+	#superclass : 'MiGithubRepository',
+	#instVars : [
+		'responses'
+	],
+	#category : 'MooseIDE-Github-Importer-Tests-Tests',
+	#package : 'MooseIDE-Github-Importer-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'credentials' }
+MiGithubRepositoryStub class >> storedGithubCredentials [
+	"For the tests I answer a fake token so that the api wiring can be tested without touching the real Iceberg credential store."
+
+	^ self pickGithubCredentialFrom: { (IceTokenCredentials new
+			   token: 'fakeToken';
+			   username: 'testUser';
+			   host: 'github.com';
+			   yourself) }
+]
+
+{ #category : 'accessing' }
+MiGithubRepositoryStub >> at: aPath put: aResponse [
+
+	responses at: aPath put: aResponse
+]
+
+{ #category : 'requesting' }
+MiGithubRepositoryStub >> get: aPath [
+
+	^ responses at: aPath ifAbsent: [ self error: 'Unexpected query: ' , aPath ]
+]
+
+{ #category : 'requesting' }
+MiGithubRepositoryStub >> get: aPath parameters: aDictionary [
+
+	^ responses at: aPath ifAbsent: [ self error: 'Unexpected query: ' , aPath ]
+]
+
+{ #category : 'initialization' }
+MiGithubRepositoryStub >> initialize [
+
+	super initialize.
+	responses := Dictionary new
+]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubRepositoryTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubRepositoryTest.class.st
@@ -81,70 +81,6 @@ MiGithubRepositoryTest >> testFromFullName [
 ]
 
 { #category : 'tests' }
-MiGithubRepositoryTest >> testFromStringEmptyInput [
-
-	self assert: (MiGithubRepository fromString: '') isNil.
-	self assert: (MiGithubRepository fromString: '   ') isNil
-]
-
-{ #category : 'tests' }
-MiGithubRepositoryTest >> testFromStringHttpsUrl [
-
-	| parsedRepository |
-	parsedRepository := MiGithubRepository fromString: 'https://github.com/pharo-project/pharo'.
-
-	self assert: parsedRepository owner equals: 'pharo-project'.
-	self assert: parsedRepository projectName equals: 'pharo'
-]
-
-{ #category : 'tests' }
-MiGithubRepositoryTest >> testFromStringHttpsUrlWithExtraSegments [
-
-	| parsedRepository |
-	parsedRepository := MiGithubRepository fromString: 'https://github.com/pharo-project/pharo/tree/P12'.
-
-	self assert: parsedRepository owner equals: 'pharo-project'.
-	self assert: parsedRepository projectName equals: 'pharo'
-]
-
-{ #category : 'tests' }
-MiGithubRepositoryTest >> testFromStringHttpsUrlWithGitSuffix [
-
-	| parsedRepository |
-	parsedRepository := MiGithubRepository fromString: 'https://github.com/pharo-project/pharo.git'.
-
-	self assert: parsedRepository owner equals: 'pharo-project'.
-	self assert: parsedRepository projectName equals: 'pharo'
-]
-
-{ #category : 'tests' }
-MiGithubRepositoryTest >> testFromStringInvalidInput [
-
-	self assert: (MiGithubRepository fromString: 'hello') isNil.
-	self assert: (MiGithubRepository fromString: 'owner/') isNil
-]
-
-{ #category : 'tests' }
-MiGithubRepositoryTest >> testFromStringOwnerAndProject [
-
-	| parsedRepository |
-	parsedRepository := MiGithubRepository fromString: 'pharo-project/pharo'.
-
-	self assert: parsedRepository owner equals: 'pharo-project'.
-	self assert: parsedRepository projectName equals: 'pharo'
-]
-
-{ #category : 'tests' }
-MiGithubRepositoryTest >> testFromStringSshUrl [
-
-	| parsedRepository |
-	parsedRepository := MiGithubRepository fromString: 'git@github.com:pharo-project/pharo.git'.
-
-	self assert: parsedRepository owner equals: 'pharo-project'.
-	self assert: parsedRepository projectName equals: 'pharo'
-]
-
-{ #category : 'tests' }
 MiGithubRepositoryTest >> testPickGithubCredentialFallsBackToPlaintext [
 
 	| plaintext |
@@ -318,7 +254,7 @@ MiGithubRepositoryTest >> testSearchRepositoriesUnknownOrganization [
 MiGithubRepositoryTest >> testSearchRepositoriesWithoutParts [
 	"The stub raises on unexpected queries, so this asserts that no query is sent when no part is given."
 
-	self assertEmpty: (repository searchRepositoriesNamed: '' organization: '   ')
+	self assertEmpty: (repository searchRepositoriesNamed: '' organization: '')
 ]
 
 { #category : 'tests' }

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubRepositoryTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubRepositoryTest.class.st
@@ -1,0 +1,343 @@
+"
+I test MiGithubRepository: parsing of the user input into a repository, mapping of Github API answers into versions and computation of the download URL. I never access the network thanks to MiGithubRepositoryStub.
+"
+Class {
+	#name : 'MiGithubRepositoryTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'repository'
+	],
+	#category : 'MooseIDE-Github-Importer-Tests-Tests',
+	#package : 'MooseIDE-Github-Importer-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'fixtures' }
+MiGithubRepositoryTest >> plaintextCredential [
+
+	^ IcePlaintextCredentials new
+		  username: 'testUser';
+		  password: 'ghp_fakePassword';
+		  host: 'github.com';
+		  yourself
+]
+
+{ #category : 'running' }
+MiGithubRepositoryTest >> setUp [
+
+	super setUp.
+	repository := MiGithubRepositoryStub owner: 'moosetechnology' projectName: 'MooseIDE'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testApiUsesStoredCredentials [
+	"The class of the stub answers a fake token credential, so the requests of the api must be authenticated with it."
+
+	self assert: repository api credentials token equals: 'fakeToken'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testAvailableVersions [
+
+	repository
+		at: 'repos/moosetechnology/MooseIDE/tags' put: { { ('name' -> 'v1.0') } asDictionary };
+		at: 'repos/moosetechnology/MooseIDE/branches' put: { { ('name' -> 'main') } asDictionary };
+		at: 'repos/moosetechnology/MooseIDE/releases' put: { { ('tag_name' -> 'v1.0') } asDictionary };
+		at: 'repos/moosetechnology/MooseIDE/pulls' put: { {
+				('number' -> 42).
+				('title' -> 'Fix bug') } asDictionary }.
+
+	self assert: repository availableVersions size equals: 4
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testBranches [
+
+	repository at: 'repos/moosetechnology/MooseIDE/branches' put: { { ('name' -> 'main') } asDictionary }.
+
+	self assert: repository branches size equals: 1.
+	self assert: repository branches anyOne displayName equals: 'main'.
+	self assert: repository branches anyOne kind equals: #branch.
+	self assert: repository branches anyOne downloadRef equals: 'refs/heads/main'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testDownloadUrlForVersion [
+
+	| version |
+	version := MiGithubVersion tagNamed: 'v1.0'.
+
+	self assert: (repository downloadUrlForVersion: version) equals: 'https://codeload.github.com/moosetechnology/MooseIDE/tar.gz/refs/tags/v1.0'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testFromFullName [
+
+	| parsedRepository |
+	parsedRepository := MiGithubRepository fromFullName: 'moosetechnology/MooseIDE'.
+
+	self assert: parsedRepository owner equals: 'moosetechnology'.
+	self assert: parsedRepository projectName equals: 'MooseIDE'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testFromStringEmptyInput [
+
+	self assert: (MiGithubRepository fromString: '') isNil.
+	self assert: (MiGithubRepository fromString: '   ') isNil
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testFromStringHttpsUrl [
+
+	| parsedRepository |
+	parsedRepository := MiGithubRepository fromString: 'https://github.com/pharo-project/pharo'.
+
+	self assert: parsedRepository owner equals: 'pharo-project'.
+	self assert: parsedRepository projectName equals: 'pharo'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testFromStringHttpsUrlWithExtraSegments [
+
+	| parsedRepository |
+	parsedRepository := MiGithubRepository fromString: 'https://github.com/pharo-project/pharo/tree/P12'.
+
+	self assert: parsedRepository owner equals: 'pharo-project'.
+	self assert: parsedRepository projectName equals: 'pharo'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testFromStringHttpsUrlWithGitSuffix [
+
+	| parsedRepository |
+	parsedRepository := MiGithubRepository fromString: 'https://github.com/pharo-project/pharo.git'.
+
+	self assert: parsedRepository owner equals: 'pharo-project'.
+	self assert: parsedRepository projectName equals: 'pharo'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testFromStringInvalidInput [
+
+	self assert: (MiGithubRepository fromString: 'hello') isNil.
+	self assert: (MiGithubRepository fromString: 'owner/') isNil
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testFromStringOwnerAndProject [
+
+	| parsedRepository |
+	parsedRepository := MiGithubRepository fromString: 'pharo-project/pharo'.
+
+	self assert: parsedRepository owner equals: 'pharo-project'.
+	self assert: parsedRepository projectName equals: 'pharo'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testFromStringSshUrl [
+
+	| parsedRepository |
+	parsedRepository := MiGithubRepository fromString: 'git@github.com:pharo-project/pharo.git'.
+
+	self assert: parsedRepository owner equals: 'pharo-project'.
+	self assert: parsedRepository projectName equals: 'pharo'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testPickGithubCredentialFallsBackToPlaintext [
+
+	| plaintext |
+	plaintext := self plaintextCredential.
+
+	self assert: (MiGithubRepository pickGithubCredentialFrom: { plaintext }) identicalTo: plaintext
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testPickGithubCredentialIgnoresEmptyCredentials [
+
+	| emptyToken |
+	emptyToken := IceTokenCredentials new
+		              token: '';
+		              host: 'github.com';
+		              yourself.
+
+	self assert: (MiGithubRepository pickGithubCredentialFrom: { emptyToken }) isNil
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testPickGithubCredentialIgnoresOtherHosts [
+
+	| otherHostToken |
+	otherHostToken := IceTokenCredentials new
+		                  token: 'ghp_sometoken';
+		                  host: 'gitlab.com';
+		                  yourself.
+
+	self assert: (MiGithubRepository pickGithubCredentialFrom: { otherHostToken }) isNil
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testPickGithubCredentialPrefersToken [
+
+	| token |
+	token := self tokenCredential.
+
+	self
+		assert: (MiGithubRepository pickGithubCredentialFrom: {
+					 token.
+					 self plaintextCredential })
+		identicalTo: token
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testPickGithubCredentialWithoutCredentials [
+
+	self assert: (MiGithubRepository pickGithubCredentialFrom: {  }) isNil
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testPrimaryLanguage [
+
+	repository at: 'repos/moosetechnology/MooseIDE' put: { ('language' -> 'Java') } asDictionary.
+
+	self assert: repository primaryLanguage equals: 'Java'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testPrimaryLanguageUnknown [
+
+	repository at: 'repos/moosetechnology/MooseIDE' put: { ('language' -> nil) } asDictionary.
+
+	self assert: repository primaryLanguage isNil
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testPullRequests [
+
+	repository at: 'repos/moosetechnology/MooseIDE/pulls' put: { {
+			('number' -> 42).
+			('title' -> 'Fix bug') } asDictionary }.
+
+	self assert: repository pullRequests size equals: 1.
+	self assert: repository pullRequests anyOne displayName equals: 'Pull request #42: Fix bug'.
+	self assert: repository pullRequests anyOne kind equals: #pullRequest.
+	self assert: repository pullRequests anyOne downloadRef equals: 'refs/pull/42/head'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testReleases [
+
+	repository at: 'repos/moosetechnology/MooseIDE/releases' put: { { ('tag_name' -> 'v1.0') } asDictionary }.
+
+	self assert: repository releases size equals: 1.
+	self assert: repository releases anyOne displayName equals: 'v1.0'.
+	self assert: repository releases anyOne kind equals: #release.
+	self assert: repository releases anyOne downloadRef equals: 'refs/tags/v1.0'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testRepositorySearchQueryDropsOwnersWhenTooLong [
+
+	| longLogins query |
+	longLogins := (1 to: 20) collect: [ :each | 'aVeryLongOwnerLoginName' , each asString ].
+	query := repository repositorySearchQueryFromNamePart: 'Tiny' ownerLogins: longLogins.
+
+	self assert: query size <= MiGithubRepository maximumSearchQuerySize.
+	self assert: (query beginsWith: 'Tiny in:name')
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testRepositorySearchQueryFromLoginsOnly [
+
+	self assert: (repository repositorySearchQueryFromNamePart: '' ownerLogins: { 'jecisc'. 'jech' }) equals: 'user:jecisc user:jech'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testRepositorySearchQueryFromNamePartAndLogins [
+
+	self assert: (repository repositorySearchQueryFromNamePart: 'Tiny' ownerLogins: { 'jecisc' }) equals: 'Tiny in:name user:jecisc'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testRepositorySearchQueryFromNamePartOnly [
+
+	self assert: (repository repositorySearchQueryFromNamePart: 'Tiny' ownerLogins: #(  )) equals: 'Tiny in:name'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testSearchOwnerLoginsFromOrganizationPart [
+
+	repository at: 'search/users' put: { ('items' -> {
+			 { ('login' -> 'jecisc') } asDictionary.
+			 { ('login' -> 'jech') } asDictionary } asArray) } asDictionary.
+
+	self assert: (repository searchOwnerLoginsFromOrganizationPart: 'jec') equals: { 'jecisc'. 'jech' }
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testSearchRepositoriesNameOnly [
+	"The search of users must not be queried when no organization part is given: the stub raises on unexpected queries."
+
+	repository at: 'search/repositories' put: { ('items' -> { { ('full_name' -> 'jecisc/TinyLogger') } asDictionary } asArray) } asDictionary.
+
+	self assert: (repository searchRepositoriesNamed: 'Tiny' organization: '') size equals: 1
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testSearchRepositoriesNamedAndOrganization [
+
+	repository
+		at: 'search/users' put: { ('items' -> { { ('login' -> 'jecisc') } asDictionary } asArray) } asDictionary;
+		at: 'search/repositories' put: { ('items' -> { { ('full_name' -> 'jecisc/TinyLogger') } asDictionary } asArray) } asDictionary.
+
+	self assert: (repository searchRepositoriesNamed: 'Tiny' organization: 'jec') size equals: 1.
+	self assert: ((repository searchRepositoriesNamed: 'Tiny' organization: 'jec') first at: 'full_name') equals: 'jecisc/TinyLogger'
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testSearchRepositoriesOrganizationOnly [
+
+	repository
+		at: 'search/users' put: { ('items' -> { { ('login' -> 'jecisc') } asDictionary } asArray) } asDictionary;
+		at: 'search/repositories' put: { ('items' -> { { ('full_name' -> 'jecisc/TinyLogger') } asDictionary } asArray) } asDictionary.
+
+	self assert: (repository searchRepositoriesNamed: '' organization: 'jec') size equals: 1
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testSearchRepositoriesUnknownOrganization [
+	"When the organization part matches no owner the search must answer empty without querying the repositories: the stub raises on unexpected queries."
+
+	repository at: 'search/users' put: { ('items' -> #(  )) } asDictionary.
+
+	self assertEmpty: (repository searchRepositoriesNamed: 'Tiny' organization: 'zzzqqq')
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testSearchRepositoriesWithoutParts [
+	"The stub raises on unexpected queries, so this asserts that no query is sent when no part is given."
+
+	self assertEmpty: (repository searchRepositoriesNamed: '' organization: '   ')
+]
+
+{ #category : 'tests' }
+MiGithubRepositoryTest >> testTags [
+
+	repository at: 'repos/moosetechnology/MooseIDE/tags' put: { { ('name' -> 'v1.0') } asDictionary }.
+
+	self assert: repository tags size equals: 1.
+	self assert: repository tags anyOne displayName equals: 'v1.0'.
+	self assert: repository tags anyOne kind equals: #tag.
+	self assert: repository tags anyOne downloadRef equals: 'refs/tags/v1.0'
+]
+
+{ #category : 'fixtures' }
+MiGithubRepositoryTest >> tokenCredential [
+
+	^ IceTokenCredentials new
+		  token: 'ghp_fakeToken';
+		  username: 'testUser';
+		  host: 'github.com';
+		  yourself
+]

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubVersionTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubVersionTest.class.st
@@ -16,15 +16,6 @@ MiGithubVersionTest >> testBranchFolderNameWithSlash [
 ]
 
 { #category : 'tests' }
-MiGithubVersionTest >> testIconName [
-
-	self assert: (MiGithubVersion tagNamed: 'v1.0') iconName equals: #glamorousBookmark.
-	self assert: (MiGithubVersion releaseNamed: 'v1.0') iconName equals: #glamorousBookmark.
-	self assert: (MiGithubVersion branchNamed: 'main') iconName equals: #branch.
-	self assert: (MiGithubVersion pullRequestNumber: 42 title: 'Fix bug') iconName equals: #merge
-]
-
-{ #category : 'tests' }
 MiGithubVersionTest >> testPullRequestDownloadRef [
 
 	self assert: (MiGithubVersion pullRequestNumber: 42 title: 'Fix bug') downloadRef equals: 'refs/pull/42/head'

--- a/src/MooseIDE-Github-Importer-Tests/MiGithubVersionTest.class.st
+++ b/src/MooseIDE-Github-Importer-Tests/MiGithubVersionTest.class.st
@@ -1,0 +1,49 @@
+"
+I test MiGithubVersion: the refs used to download a version and the name of its download folder.
+"
+Class {
+	#name : 'MiGithubVersionTest',
+	#superclass : 'TestCase',
+	#category : 'MooseIDE-Github-Importer-Tests-Tests',
+	#package : 'MooseIDE-Github-Importer-Tests',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+MiGithubVersionTest >> testBranchFolderNameWithSlash [
+
+	self assert: (MiGithubVersion branchNamed: 'feature/my-branch') folderName equals: 'feature-my-branch'
+]
+
+{ #category : 'tests' }
+MiGithubVersionTest >> testIconName [
+
+	self assert: (MiGithubVersion tagNamed: 'v1.0') iconName equals: #glamorousBookmark.
+	self assert: (MiGithubVersion releaseNamed: 'v1.0') iconName equals: #glamorousBookmark.
+	self assert: (MiGithubVersion branchNamed: 'main') iconName equals: #branch.
+	self assert: (MiGithubVersion pullRequestNumber: 42 title: 'Fix bug') iconName equals: #merge
+]
+
+{ #category : 'tests' }
+MiGithubVersionTest >> testPullRequestDownloadRef [
+
+	self assert: (MiGithubVersion pullRequestNumber: 42 title: 'Fix bug') downloadRef equals: 'refs/pull/42/head'
+]
+
+{ #category : 'tests' }
+MiGithubVersionTest >> testPullRequestFolderName [
+
+	self assert: (MiGithubVersion pullRequestNumber: 42 title: 'Fix bug') folderName equals: 'PR-42'
+]
+
+{ #category : 'tests' }
+MiGithubVersionTest >> testReleaseDownloadRef [
+
+	self assert: (MiGithubVersion releaseNamed: 'v1.0') downloadRef equals: 'refs/tags/v1.0'
+]
+
+{ #category : 'tests' }
+MiGithubVersionTest >> testTagFolderName [
+
+	self assert: (MiGithubVersion tagNamed: 'v1.0') folderName equals: 'v1.0'
+]

--- a/src/MooseIDE-Github-Importer-Tests/package.st
+++ b/src/MooseIDE-Github-Importer-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'MooseIDE-Github-Importer-Tests' }

--- a/src/MooseIDE-Github-Importer/MiGithubImportPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImportPresenter.class.st
@@ -168,7 +168,7 @@ MiGithubImportPresenter >> searchRepositories [
 			^ self ].
 
 	[
-		(MiGithubRepository searchRepositoriesNamed: repositoryNameInput text organization: organizationInput text)
+		(MiGithubRepository searchRepositoriesNamed: repositoryNameInput text trim organization: organizationInput text trim)
 			ifEmpty: [
 					self alert: 'No repository found for this search.'.
 					^ self ]

--- a/src/MooseIDE-Github-Importer/MiGithubImportPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImportPresenter.class.st
@@ -1,0 +1,201 @@
+"
+I am the entry point of the Github importer UI (see MiGithubImporter), inspired by the Software Heritage importer.
+
+The user enters a part of the name of an organization and/or a part of a project name and I list the matching Github repositories in the top table (see MiGithubRepository class>>searchRepositoriesNamed:organization:).
+When the user selects a repository I check that the project is written in Java (if not I inform the user that it is not supported yet), fetch its available versions and display them with checkboxes in the bottom table (see MiGithubTargetSelectionPresenter) so that the user selects the versions to download and import.
+
+I can be opened:
+- from the ""Import"" toolbar of the models browser through MiImportFromGithubCommand
+- from the Moose world menu entry ""Github Importer""
+"
+Class {
+	#name : 'MiGithubImportPresenter',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'organizationInput',
+		'repositoryNameInput',
+		'searchButton',
+		'tokenButton',
+		'repositoriesTable',
+		'versionsLabel',
+		'versionsPresenter'
+	],
+	#category : 'MooseIDE-Github-Importer-UI',
+	#package : 'MooseIDE-Github-Importer',
+	#tag : 'UI'
+}
+
+{ #category : 'opening' }
+MiGithubImportPresenter class >> open [
+
+	<script>
+	^ self new
+		  openDialog;
+		  yourself
+]
+
+{ #category : 'specs' }
+MiGithubImportPresenter class >> title [
+
+	^ 'Github Importer'
+]
+
+{ #category : 'action' }
+MiGithubImportPresenter >> clearVersions [
+
+	versionsPresenter
+		repository: nil;
+		versions: #(  )
+]
+
+{ #category : 'layout' }
+MiGithubImportPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: (SpBoxLayout newLeftToRight
+				   add: organizationInput;
+				   add: repositoryNameInput;
+				   add: searchButton expand: false;
+				   add: tokenButton expand: false;
+				   yourself)
+		  expand: false;
+		  add: repositoriesTable;
+		  add: versionsLabel expand: false;
+		  add: versionsPresenter;
+		  yourself
+]
+
+{ #category : 'accessing' }
+MiGithubImportPresenter >> fetchVersionsButton [
+	^ fetchVersionsButton
+]
+
+{ #category : 'initialization' }
+MiGithubImportPresenter >> initializePresenters [
+
+	super initializePresenters.
+	organizationInput := self newTextInput
+		                     placeholder: 'organization, e.g. moosetechnology';
+		                     whenSubmitDo: [ :inputText | self searchRepositories ];
+		                     yourself.
+	repositoryNameInput := self newTextInput
+		                       placeholder: 'project name, e.g. MooseIDE';
+		                       whenSubmitDo: [ :inputText | self searchRepositories ];
+		                       yourself.
+	searchButton := self newButton
+		                label: 'Search';
+		                icon: (self iconNamed: #smallFind);
+		                action: [ self searchRepositories ];
+		                yourself.
+	tokenButton := self newButton
+		               label: 'Github token...';
+		               icon: (self iconNamed: #github);
+		               help:
+			               'Store a Github personal access token to authenticate the requests and raise the rate limit from 60 to 5000 requests per hour. Note: the Iceberg credential store keeps one credential per host, storing a token replaces the github.com credential.';
+		               action: [ self openTokenDialog ];
+		               yourself.
+	repositoriesTable := self newTable
+		                     addColumn: (SpStringTableColumn title: 'Repository' evaluated: [ :item | (item at: 'full_name' ifAbsent: [ '' ]) ifNil: [ '' ] ]);
+		                     addColumn: (SpStringTableColumn title: 'Language' evaluated: [ :item | (item at: 'language' ifAbsent: [ '' ]) ifNil: [ '' ] ]);
+		                     addColumn: (SpStringTableColumn title: 'Description' evaluated: [ :item | (item at: 'description' ifAbsent: [ '' ]) ifNil: [ '' ] ]);
+		                     items: #(  );
+		                     whenSelectionChangedDo: [ :selection |
+				                     selection isEmpty
+					                     ifTrue: [ self clearVersions ]
+					                     ifFalse: [ self loadVersionsForSelectedRepository ] ];
+		                     yourself.
+	versionsLabel := self newLabel label: 'Versions of the selected project'.
+	versionsPresenter := self instantiate: MiGithubTargetSelectionPresenter
+]
+
+{ #category : 'initialization' }
+MiGithubImportPresenter >> initializeWindow: aWindowPresenter [
+
+	super initializeWindow: aWindowPresenter.
+	aWindowPresenter title: self class title.
+	aWindowPresenter initialExtent: 600 @ 700
+]
+
+{ #category : 'action' }
+MiGithubImportPresenter >> loadVersionsForSelectedRepository [
+
+	| repository |
+	repository := MiGithubRepository fromFullName: (repositoriesTable selection selectedItem at: 'full_name').
+	[ self showVersionsFor: repository ]
+		on: IceGitHubError
+		do: [ :error |
+				UIManager default alert: 'Cannot access the Github repository: ' , error messageText.
+				self clearVersions ]
+]
+
+{ #category : 'world menu' }
+MiGithubImportPresenter >> menuCommandOn: aBuilder [
+
+	<worldMenu>
+	^ aBuilder
+		  item: #MooseGithubImporter;
+		  parent: #Moose;
+		  label: self title;
+		  icon: (Smalltalk ui icons iconNamed: #github);
+		  help: 'Import the sources of versions of a Github project and create Famix models from them (Java only for now)';
+		  action: [ self open ];
+		  yourself
+]
+
+{ #category : 'action' }
+MiGithubImportPresenter >> openTokenDialog [
+
+	MiGithubTokenPresenter new openDialog centeredRelativeTo: self window
+]
+
+{ #category : 'accessing' }
+MiGithubImportPresenter >> organizationInput [
+	^ organizationInput
+]
+
+{ #category : 'accessing' }
+MiGithubImportPresenter >> repositoriesTable [
+	^ repositoriesTable
+]
+
+{ #category : 'accessing' }
+MiGithubImportPresenter >> repositoryNameInput [
+	^ repositoryNameInput
+]
+
+{ #category : 'action' }
+MiGithubImportPresenter >> searchRepositories [
+
+	| searchResults |
+	(organizationInput text isEmpty and: [ repositoryNameInput text isEmpty ]) ifTrue: [
+			UIManager default alert: 'Enter at least a part of the organization or of the project name.'.
+			^ self ].
+	[
+		searchResults := MiGithubRepository searchRepositoriesNamed: repositoryNameInput text organization: organizationInput text.
+		searchResults ifEmpty: [
+				UIManager default alert: 'No repository found for this search.'.
+				^ self ].
+		repositoriesTable items: searchResults ]
+		on: IceGitHubError
+		do: [ :error | UIManager default alert: 'Cannot search on Github: ' , error messageText ]
+]
+
+{ #category : 'action' }
+MiGithubImportPresenter >> showVersionsFor: aRepository [
+
+	| primaryLanguage |
+	primaryLanguage := aRepository primaryLanguage.
+	(MiGithubImporter isLanguageSupported: primaryLanguage) ifFalse: [
+			UIManager default alert: ('The project "{1}" is written in {2}. Only Java projects are supported for now.' format: {
+						 aRepository projectName.
+						 (primaryLanguage ifNil: [ 'an unknown language' ]) }).
+			^ self clearVersions ].
+	versionsPresenter
+		repository: aRepository;
+		versions: aRepository availableVersions
+]
+
+{ #category : 'accessing' }
+MiGithubImportPresenter >> versionsPresenter [
+	^ versionsPresenter
+]

--- a/src/MooseIDE-Github-Importer/MiGithubImportPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImportPresenter.class.st
@@ -10,7 +10,7 @@ I can be opened:
 "
 Class {
 	#name : 'MiGithubImportPresenter',
-	#superclass : 'SpPresenter',
+	#superclass : 'MiImportModelDialog',
 	#instVars : [
 		'organizationInput',
 		'repositoryNameInput',
@@ -38,17 +38,16 @@ MiGithubImportPresenter class >> menuCommandOn: aBuilder [
 		  yourself
 ]
 
-{ #category : 'opening' }
-MiGithubImportPresenter class >> open [
-
-	<script>
-	^ self new open
-]
-
 { #category : 'specs' }
 MiGithubImportPresenter class >> title [
 
 	^ 'Github Importer'
+]
+
+{ #category : 'specs' }
+MiGithubImportPresenter class >> windowExtent [
+
+	^ 600 @ 700
 ]
 
 { #category : 'action' }
@@ -72,6 +71,17 @@ MiGithubImportPresenter >> defaultLayout [
 		  add: 'Versions of the selected project' expand: false;
 		  add: versionsPresenter;
 		  yourself
+]
+
+{ #category : 'action' }
+MiGithubImportPresenter >> importModel [
+	"Like MiImportModelFromFoldersDialog, I import several models: the check that they are not empty is adapted from MiImportModelDialog>>importModel for a single model."
+
+	| mooseModelsWrapper |
+	mooseModelsWrapper := self privateImportModel.
+	mooseModelsWrapper models do: [ :each |
+		(each size - (each allUsing: FamixTSourceLanguage) size) isZero ifTrue: [ self error: 'Something is wrong, the imported model appears to be empty' ] ].
+	^ mooseModelsWrapper
 ]
 
 { #category : 'initialization' }
@@ -110,14 +120,6 @@ MiGithubImportPresenter >> initializePresenters [
 	versionsPresenter := self instantiate: MiGithubTargetSelectionPresenter
 ]
 
-{ #category : 'initialization' }
-MiGithubImportPresenter >> initializeWindow: aWindowPresenter [
-
-	super initializeWindow: aWindowPresenter.
-	aWindowPresenter title: self class title.
-	aWindowPresenter initialExtent: 600 @ 700
-]
-
 { #category : 'action' }
 MiGithubImportPresenter >> loadVersionsForSelectedRepository [
 
@@ -139,6 +141,13 @@ MiGithubImportPresenter >> openTokenDialog [
 { #category : 'accessing' }
 MiGithubImportPresenter >> organizationInput [
 	^ organizationInput
+]
+
+{ #category : 'action' }
+MiGithubImportPresenter >> privateImportModel [
+	"I download the sources of the selected versions and parse them into models."
+
+	^ MiMooseModelsWrapper models: (MiGithubImporter downloadAndImport: versionsPresenter selectedVersions from: versionsPresenter repository)
 ]
 
 { #category : 'accessing' }
@@ -169,6 +178,14 @@ MiGithubImportPresenter >> searchRepositories [
 ]
 
 { #category : 'action' }
+MiGithubImportPresenter >> shouldCreateCache [
+	"The models browser can be absent (dialog opened from the world menu), in that case I use the default."
+
+	self application currentModelsBrowser ifNil: [ ^ true ].
+	^ super shouldCreateCache
+]
+
+{ #category : 'action' }
 MiGithubImportPresenter >> showVersionsFor: aRepository [
 
 	(MiGithubImporter isLanguageSupported: aRepository primaryLanguage) ifFalse: [
@@ -180,6 +197,12 @@ MiGithubImportPresenter >> showVersionsFor: aRepository [
 	versionsPresenter
 		repository: aRepository;
 		versions: aRepository availableVersions
+]
+
+{ #category : 'action' }
+MiGithubImportPresenter >> validateImportForm [
+
+	versionsPresenter selectedVersions ifEmpty: [ self error: 'Please select at least one version to import.' ]
 ]
 
 { #category : 'accessing' }

--- a/src/MooseIDE-Github-Importer/MiGithubImportPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImportPresenter.class.st
@@ -1,11 +1,11 @@
 "
-I am the entry point of the Github importer UI (see MiGithubImporter), inspired by the Software Heritage importer.
+I am the entry point of the Github importer UI (see `MiGithubImporter`).
 
-The user enters a part of the name of an organization and/or a part of a project name and I list the matching Github repositories in the top table (see MiGithubRepository class>>searchRepositoriesNamed:organization:).
-When the user selects a repository I check that the project is written in Java (if not I inform the user that it is not supported yet), fetch its available versions and display them with checkboxes in the bottom table (see MiGithubTargetSelectionPresenter) so that the user selects the versions to download and import.
+The user enters a part of the name of an organization and/or a part of a project name and I list the matching Github repositories in the top table (see `MiGithubRepository class>>searchRepositoriesNamed:organization:` ).
+When the user selects a repository I check that the project is written in Java (if not I inform the user that it is not supported yet), fetch its available versions and display them with checkboxes in the bottom table (see `MiGithubTargetSelectionPresenter`) so that the user selects the versions to download and import.
 
 I can be opened:
-- from the ""Import"" toolbar of the models browser through MiImportFromGithubCommand
+- from the ""Import"" toolbar of the models browser through `MiImportFromGithubCommand`
 - from the Moose world menu entry ""Github Importer""
 "
 Class {
@@ -17,7 +17,6 @@ Class {
 		'searchButton',
 		'tokenButton',
 		'repositoriesTable',
-		'versionsLabel',
 		'versionsPresenter'
 	],
 	#category : 'MooseIDE-Github-Importer-UI',
@@ -25,13 +24,25 @@ Class {
 	#tag : 'UI'
 }
 
+{ #category : 'world menu' }
+MiGithubImportPresenter class >> menuCommandOn: aBuilder [
+
+	<worldMenu>
+	^ aBuilder
+		  item: #MooseGithubImporter;
+		  parent: #Moose;
+		  label: self title;
+		  icon: (Smalltalk ui icons iconNamed: #github);
+		  help: 'Import the sources of versions of a Github project and create Famix models from them (Java only for now)';
+		  action: [ self open ];
+		  yourself
+]
+
 { #category : 'opening' }
 MiGithubImportPresenter class >> open [
 
 	<script>
-	^ self new
-		  openDialog;
-		  yourself
+	^ self new open
 ]
 
 { #category : 'specs' }
@@ -43,9 +54,7 @@ MiGithubImportPresenter class >> title [
 { #category : 'action' }
 MiGithubImportPresenter >> clearVersions [
 
-	versionsPresenter
-		repository: nil;
-		versions: #(  )
+	versionsPresenter clearVersions
 ]
 
 { #category : 'layout' }
@@ -60,14 +69,9 @@ MiGithubImportPresenter >> defaultLayout [
 				   yourself)
 		  expand: false;
 		  add: repositoriesTable;
-		  add: versionsLabel expand: false;
+		  add: 'Versions of the selected project' expand: false;
 		  add: versionsPresenter;
 		  yourself
-]
-
-{ #category : 'accessing' }
-MiGithubImportPresenter >> fetchVersionsButton [
-	^ fetchVersionsButton
 ]
 
 { #category : 'initialization' }
@@ -98,13 +102,11 @@ MiGithubImportPresenter >> initializePresenters [
 		                     addColumn: (SpStringTableColumn title: 'Repository' evaluated: [ :item | (item at: 'full_name' ifAbsent: [ '' ]) ifNil: [ '' ] ]);
 		                     addColumn: (SpStringTableColumn title: 'Language' evaluated: [ :item | (item at: 'language' ifAbsent: [ '' ]) ifNil: [ '' ] ]);
 		                     addColumn: (SpStringTableColumn title: 'Description' evaluated: [ :item | (item at: 'description' ifAbsent: [ '' ]) ifNil: [ '' ] ]);
-		                     items: #(  );
 		                     whenSelectionChangedDo: [ :selection |
 				                     selection isEmpty
 					                     ifTrue: [ self clearVersions ]
 					                     ifFalse: [ self loadVersionsForSelectedRepository ] ];
 		                     yourself.
-	versionsLabel := self newLabel label: 'Versions of the selected project'.
 	versionsPresenter := self instantiate: MiGithubTargetSelectionPresenter
 ]
 
@@ -124,22 +126,8 @@ MiGithubImportPresenter >> loadVersionsForSelectedRepository [
 	[ self showVersionsFor: repository ]
 		on: IceGitHubError
 		do: [ :error |
-				UIManager default alert: 'Cannot access the Github repository: ' , error messageText.
+				self alert: 'Cannot access the Github repository: ' , error messageText.
 				self clearVersions ]
-]
-
-{ #category : 'world menu' }
-MiGithubImportPresenter >> menuCommandOn: aBuilder [
-
-	<worldMenu>
-	^ aBuilder
-		  item: #MooseGithubImporter;
-		  parent: #Moose;
-		  label: self title;
-		  icon: (Smalltalk ui icons iconNamed: #github);
-		  help: 'Import the sources of versions of a Github project and create Famix models from them (Java only for now)';
-		  action: [ self open ];
-		  yourself
 ]
 
 { #category : 'action' }
@@ -166,30 +154,29 @@ MiGithubImportPresenter >> repositoryNameInput [
 { #category : 'action' }
 MiGithubImportPresenter >> searchRepositories [
 
-	| searchResults |
 	(organizationInput text isEmpty and: [ repositoryNameInput text isEmpty ]) ifTrue: [
-			UIManager default alert: 'Enter at least a part of the organization or of the project name.'.
+			self alert: 'Enter at least a part of the organization or of the project name.'.
 			^ self ].
+
 	[
-		searchResults := MiGithubRepository searchRepositoriesNamed: repositoryNameInput text organization: organizationInput text.
-		searchResults ifEmpty: [
-				UIManager default alert: 'No repository found for this search.'.
-				^ self ].
-		repositoriesTable items: searchResults ]
+		(MiGithubRepository searchRepositoriesNamed: repositoryNameInput text organization: organizationInput text)
+			ifEmpty: [
+					self alert: 'No repository found for this search.'.
+					^ self ]
+			ifNotEmpty: [ :searchResults | repositoriesTable items: searchResults ] ]
 		on: IceGitHubError
-		do: [ :error | UIManager default alert: 'Cannot search on Github: ' , error messageText ]
+		do: [ :error | self alert: 'Cannot search on Github: ' , error messageText ]
 ]
 
 { #category : 'action' }
 MiGithubImportPresenter >> showVersionsFor: aRepository [
 
-	| primaryLanguage |
-	primaryLanguage := aRepository primaryLanguage.
-	(MiGithubImporter isLanguageSupported: primaryLanguage) ifFalse: [
-			UIManager default alert: ('The project "{1}" is written in {2}. Only Java projects are supported for now.' format: {
+	(MiGithubImporter isLanguageSupported: aRepository primaryLanguage) ifFalse: [
+			self alert: ('The project "{1}" is written in {2}. Only Java projects are supported for now.' format: {
 						 aRepository projectName.
-						 (primaryLanguage ifNil: [ 'an unknown language' ]) }).
+						 (aRepository primaryLanguage ifNil: [ 'an unknown language' ]) }).
 			^ self clearVersions ].
+
 	versionsPresenter
 		repository: aRepository;
 		versions: aRepository availableVersions

--- a/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
@@ -95,10 +95,9 @@ MiGithubImporter >> downloadVersion: aVersion [
 	"I download and extract the sources of aVersion in a dedicated folder of the cache directory. I answer the downloaded folder."
 
 	| folder |
-	folder := self folderForVersion: aVersion.
-	folder ensureDeleteAll.
-	folder parent ensureCreateDirectory.
-	folder ensureCreateDirectory.
+	folder := (self folderForVersion: aVersion)
+		          ensureDeleteAll;
+		          ensureCreateDirectory.
 	self downloadAndExtractTarballOf: aVersion in: folder.
 	^ folder
 ]

--- a/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
@@ -121,9 +121,20 @@ MiGithubImporter >> folderForVersion: aVersion [
 
 { #category : 'actions' }
 MiGithubImporter >> import [
-	"I parse the downloaded folders with VerveineJ through FamixJavaFoldersImporter and I answer the resulting models. I do not install the models: it is the role of the import dialog, with the cache setting of the models browser (see MiImportModelDialog>>importModelStep2Install:)."
+	"I parse the downloaded folders with VerveineJ through FamixJavaFoldersImporter and I answer the resulting models. I name each model with the project name prefixed to the version folder name, with the potential special characters replaced by dashes (for example 'VerveineJ-v5'). I do not install the models: it is the role of the import dialog, with the cache setting of the models browser (see MiImportModelDialog>>importModelStep2Install:)."
 
-	^ FamixJavaFoldersImporter importFolders: downloadedFolders
+	| mooseModels |
+	mooseModels := FamixJavaFoldersImporter new
+		               folders: downloadedFolders;
+		               import.
+	mooseModels with: downloadedFolders do: [ :mooseModel :folder | mooseModel name: (self modelNameFromFolder: folder) ].
+	^ mooseModels
+]
+
+{ #category : 'private' }
+MiGithubImporter >> modelNameFromFolder: aFolder [
+
+	^ repository projectName , '-' , aFolder basename
 ]
 
 { #category : 'accessing' }

--- a/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
@@ -51,7 +51,7 @@ MiGithubImporter class >> isLanguageSupported: aLanguage [
 { #category : 'private' }
 MiGithubImporter >> cacheDirectory [
 
-	^ FileLocator imageDirectory / self class cacheDirectoryName
+	^ FileLocator localDirectory / self class cacheDirectoryName
 ]
 
 { #category : 'actions' }

--- a/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
@@ -1,0 +1,146 @@
+"
+I download the sources of versions of a Github project (see MiGithubRepository and MiGithubVersion) and import them in MooseIDE as Famix models.
+
+The sources are kept on disk in the 'github-moose-cache' directory next to the image, with one folder per project and one folder per version, so that the user can read the code.
+
+For each downloaded version, I parse its folder with VerveineJ through FamixJavaFoldersImporter and install the resulting model.
+
+Note: for now I only support Java projects. The check is done before with MiGithubImporter class>>isLanguageSupported:.
+
+Usage:
+```st
+MiGithubImporter downloadAndImport: { (MiGithubVersion tagNamed: 'v1.0') } from: aMiGithubRepository
+```
+"
+Class {
+	#name : 'MiGithubImporter',
+	#superclass : 'Object',
+	#instVars : [
+		'repository',
+		'versions',
+		'downloadedFolders'
+	],
+	#category : 'MooseIDE-Github-Importer-Importer',
+	#package : 'MooseIDE-Github-Importer',
+	#tag : 'Importer'
+}
+
+{ #category : 'instance creation' }
+MiGithubImporter class >> cacheDirectoryName [
+	"I am the name of the directory, next to the image directory, in which the sources of the projects are downloaded."
+
+	^ 'github-moose-cache'
+]
+
+{ #category : 'instance creation' }
+MiGithubImporter class >> downloadAndImport: aCollectionOfVersions from: aMiGithubRepository [
+
+	^ self new
+		  repository: aMiGithubRepository;
+		  versions: aCollectionOfVersions;
+		  downloadAndImport
+]
+
+{ #category : 'testing' }
+MiGithubImporter class >> isLanguageSupported: aLanguage [
+	"For now I only support Java projects."
+
+	^ aLanguage = 'Java'
+]
+
+{ #category : 'private' }
+MiGithubImporter >> cacheDirectory [
+
+	^ FileLocator imageDirectory / self class cacheDirectoryName
+]
+
+{ #category : 'actions' }
+MiGithubImporter >> download [
+	"I download the sources of each version to import, with a job to show the progression."
+
+	downloadedFolders := OrderedCollection new.
+	[ :job |
+		versions doWithIndex: [ :aVersion :index |
+				job
+					title: 'Downloading ' , aVersion displayName;
+					progress: index - 1 / versions size.
+				downloadedFolders add: (self downloadVersion: aVersion) ].
+		job progress: 1 ] asJob run
+]
+
+{ #category : 'private' }
+MiGithubImporter >> downloadAndExtractTarballOf: aVersion in: aFolder [
+
+	| archiveReference |
+	archiveReference := self cacheDirectory / (aVersion folderName , '.tar.gz').
+	archiveReference parent ensureCreateDirectory.
+	(ZnClient new
+		 url: (repository downloadUrlForVersion: aVersion);
+		 downloadTo: archiveReference pathString) ifFalse: [ self error: 'Cannot download the sources of ' , aVersion displayName ].
+	LibC runCommand: 'tar -xzvf "' , archiveReference pathString , '" -C "' , aFolder pathString , '" --strip-components=1'.
+	archiveReference ensureDelete
+]
+
+{ #category : 'actions' }
+MiGithubImporter >> downloadAndImport [
+	"I download the sources of all the versions and then import and install a model for each downloaded folder."
+
+	self download.
+	^ self import
+]
+
+{ #category : 'private' }
+MiGithubImporter >> downloadVersion: aVersion [
+	"I download and extract the sources of aVersion in a dedicated folder of the cache directory. I answer the downloaded folder."
+
+	| folder |
+	folder := self folderForVersion: aVersion.
+	folder ensureDeleteAll.
+	folder parent ensureCreateDirectory.
+	folder ensureCreateDirectory.
+	self downloadAndExtractTarballOf: aVersion in: folder.
+	^ folder
+]
+
+{ #category : 'accessing' }
+MiGithubImporter >> downloadedFolders [
+
+	^ downloadedFolders
+]
+
+{ #category : 'private' }
+MiGithubImporter >> folderForVersion: aVersion [
+
+	^ self cacheDirectory / repository projectName / aVersion folderName
+]
+
+{ #category : 'actions' }
+MiGithubImporter >> import [
+	"I parse with VerveineJ through FamixJavaFoldersImporter and install a model for each downloaded folder."
+
+	^ FamixJavaFoldersImporter importAndInstallFolders: downloadedFolders
+]
+
+{ #category : 'accessing' }
+MiGithubImporter >> repository [
+
+	^ repository
+]
+
+{ #category : 'accessing' }
+MiGithubImporter >> repository: anObject [
+
+	repository := anObject
+]
+
+{ #category : 'accessing' }
+MiGithubImporter >> versions [
+
+	^ versions
+]
+
+{ #category : 'accessing' }
+MiGithubImporter >> versions: anObject [
+
+	versions := anObject
+]

--- a/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
@@ -71,15 +71,20 @@ MiGithubImporter >> download [
 
 { #category : 'private' }
 MiGithubImporter >> downloadAndExtractTarballOf: aVersion in: aFolder [
+	"I download the sources of aVersion and extract them in aFolder with tar. I raise an error if the download or the extraction fails. Note: tar must be installed on the system (it is not shipped with Windows before the Windows 10 1803 update)."
 
-	| archiveReference |
+	| archiveReference tarExitCode |
 	archiveReference := self cacheDirectory / (aVersion folderName , '.tar.gz').
 	archiveReference parent ensureCreateDirectory.
 	(ZnClient new
 		 url: (repository downloadUrlForVersion: aVersion);
 		 downloadTo: archiveReference pathString) ifFalse: [ self error: 'Cannot download the sources of ' , aVersion displayName ].
-	LibC runCommand: 'tar -xzvf "' , archiveReference pathString , '" -C "' , aFolder pathString , '" --strip-components=1'.
-	archiveReference ensureDelete
+	tarExitCode := LibC runCommand: 'tar -xzvf "' , archiveReference pathString , '" -C "' , aFolder pathString , '" --strip-components=1'.
+	archiveReference ensureDelete.
+	tarExitCode isZero ifFalse: [
+			self error: ('The extraction of the sources of {1} failed (tar exited with code {2}). Please check that tar is installed on your system.' format: {
+						 aVersion displayName.
+						 tarExitCode printString }) ]
 ]
 
 { #category : 'actions' }

--- a/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubImporter.class.st
@@ -1,9 +1,9 @@
 "
-I download the sources of versions of a Github project (see MiGithubRepository and MiGithubVersion) and import them in MooseIDE as Famix models.
+I download the sources of versions of a Github project (see MiGithubRepository and MiGithubVersion) and I parse them into Famix models.
 
 The sources are kept on disk in the 'github-moose-cache' directory next to the image, with one folder per project and one folder per version, so that the user can read the code.
 
-For each downloaded version, I parse its folder with VerveineJ through FamixJavaFoldersImporter and install the resulting model.
+For each downloaded version, I parse its folder with VerveineJ through FamixJavaFoldersImporter. I do not install the models: it is the role of the import dialog (see MiGithubImportPresenter), which installs them with the cache setting of the models browser.
 
 Note: for now I only support Java projects. The check is done before with MiGithubImporter class>>isLanguageSupported:.
 
@@ -64,6 +64,7 @@ MiGithubImporter >> download [
 				job
 					title: 'Downloading ' , aVersion displayName;
 					progress: index - 1 / versions size.
+				WorldMorph doOneCycle.
 				downloadedFolders add: (self downloadVersion: aVersion) ].
 		job progress: 1 ] asJob run
 ]
@@ -83,7 +84,7 @@ MiGithubImporter >> downloadAndExtractTarballOf: aVersion in: aFolder [
 
 { #category : 'actions' }
 MiGithubImporter >> downloadAndImport [
-	"I download the sources of all the versions and then import and install a model for each downloaded folder."
+	"I download the sources of all the versions and then parse them into Famix models (without installing them)."
 
 	self download.
 	^ self import
@@ -116,9 +117,9 @@ MiGithubImporter >> folderForVersion: aVersion [
 
 { #category : 'actions' }
 MiGithubImporter >> import [
-	"I parse with VerveineJ through FamixJavaFoldersImporter and install a model for each downloaded folder."
+	"I parse the downloaded folders with VerveineJ through FamixJavaFoldersImporter and I answer the resulting models. I do not install the models: it is the role of the import dialog, with the cache setting of the models browser (see MiImportModelDialog>>importModelStep2Install:)."
 
-	^ FamixJavaFoldersImporter importAndInstallFolders: downloadedFolders
+	^ FamixJavaFoldersImporter importFolders: downloadedFolders
 ]
 
 { #category : 'accessing' }

--- a/src/MooseIDE-Github-Importer/MiGithubRepository.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubRepository.class.st
@@ -1,9 +1,7 @@
 "
 I represent a Github project (an owner and a project name) and I am the access point of the Github importer to the Github API (through IceGitHubAPI).
 
-I can be created from a user input with #fromString: which accepts 'owner/project' or the URL of a repository ('https://github.com/owner/project' or 'git@github.com:owner/project.git'), or from the full name of a repository found in a search with #fromFullName:.
-
-I can also search for repositories matching a part of a project name and/or a part of an organization name with class>>searchRepositoriesNamed:organization:.
+I can also search for repositories matching a part of a project name and/or a part of an organization name with #searchRepositoriesNamed:organization:.
 
 I query the information of the repository, its primary language and the available versions: tags, branches, releases and pull requests (see #availableVersions).
 I also know the URL from which the sources of a version can be downloaded (see #downloadUrlForVersion:).
@@ -24,50 +22,12 @@ Class {
 
 { #category : 'instance creation' }
 MiGithubRepository class >> fromFullName: aString [
-	"I create a repository from its full name on Github ('owner/project')."
-
-	^ self fromRepositoryPath: aString
-]
-
-{ #category : 'instance creation' }
-MiGithubRepository class >> fromHttpsUrl: aString [
-
-	^ self fromRepositoryPath: (aString allButFirst: 'https://github.com/' size)
-]
-
-{ #category : 'instance creation' }
-MiGithubRepository class >> fromRepositoryPath: aString [
 	"I parse the path of a repository ('owner/project' potentially followed by more path segments) into a repository. I answer nil if the path does not contain an owner and a project name."
 
 	| segments |
 	segments := (aString splitOn: $/) select: #isNotEmpty.
 	segments size < 2 ifTrue: [ ^ nil ].
 	^ self owner: segments first projectName: (segments second removeSuffix: '.git')
-]
-
-{ #category : 'instance creation' }
-MiGithubRepository class >> fromSshUrl: aString [
-
-	^ self fromRepositoryPath: (aString allButFirst: 'git@github.com:' size)
-]
-
-{ #category : 'instance creation' }
-MiGithubRepository class >> fromString: aString [
-	"I parse the input of the user, either 'owner/project' or the URL of a repository ('https://github.com/owner/project' or 'git@github.com:owner/project.git'). I answer nil if the input cannot be parsed."
-
-	| cleanedInput |
-	cleanedInput := aString trimBoth.
-	cleanedInput ifEmpty: [ ^ nil ].
-	(cleanedInput beginsWith: 'https://github.com/') ifTrue: [ ^ self fromHttpsUrl: cleanedInput ].
-	(cleanedInput beginsWith: 'git@github.com:') ifTrue: [ ^ self fromSshUrl: cleanedInput ].
-	^ self fromRepositoryPath: cleanedInput
-]
-
-{ #category : 'accessing' }
-MiGithubRepository class >> maximumOwnersInSearch [
-	"I am the number of owner logins that the resolution of the organization part of a search can keep. Github ranks the owners by relevance, an exact organization name is always resolved. It is also the page size of the user search."
-
-	^ 10
 ]
 
 { #category : 'accessing' }
@@ -104,25 +64,6 @@ MiGithubRepository class >> pickGithubCredentialFrom: aCollectionOfCredentials [
 MiGithubRepository class >> searchRepositoriesNamed: aNamePart organization: anOrganizationPart [
 
 	^ self new searchRepositoriesNamed: aNamePart organization: anOrganizationPart
-]
-
-{ #category : 'accessing' }
-MiGithubRepository class >> searchResultsPageSize [
-
-	^ 50
-]
-
-{ #category : 'credentials' }
-MiGithubRepository class >> storeToken: aToken username: aUsername [
-	"I store a Github personal access token in the Iceberg credential store for github.com to authenticate the requests of the Github API. I replace the credential stored for github.com since the store keeps one credential per host. The token is also usable for the git operations of Iceberg (the username is needed in that case)."
-
-	IceCredentialStore current
-		storeCredential: (IceTokenCredentials new
-				 token: aToken;
-				 username: aUsername;
-				 host: 'github.com';
-				 yourself)
-		forHostname: 'github.com'
 ]
 
 { #category : 'credentials' }
@@ -227,7 +168,7 @@ MiGithubRepository >> queryTermsFromNamePart: aNamePart ownerLogins: aCollection
 	| terms |
 	terms := OrderedCollection new.
 	aNamePart ifNotEmpty: [ terms add: aNamePart , ' in:name' ].
-	aCollectionOfLogins do: [ :aLogin | terms add: 'user:' , aLogin ].
+	terms addAll: (aCollectionOfLogins collect: [ :aLogin | 'user:' , aLogin ]).
 	^ terms
 ]
 
@@ -266,30 +207,30 @@ MiGithubRepository >> searchOwnerLoginsFromOrganizationPart: anOrganizationPart 
 
 	^ ((self get: 'search/users' parameters: {
 			    ('q' -> (anOrganizationPart , ' in:login')).
-			    ('per_page' -> self class maximumOwnersInSearch) } asDictionary) at: 'items') collect: [ :each | each at: 'login' ]
+			    ('per_page' -> 20) } asDictionary) at: 'items') collect: [ :each | each at: 'login' ]
 ]
 
 { #category : 'requesting' }
 MiGithubRepository >> searchRepositoriesFromQuery: aQuery [
+	"We display 50 results by page."
 
 	^ (self get: 'search/repositories' parameters: {
 			   ('q' -> aQuery).
-			   ('per_page' -> self class searchResultsPageSize) } asDictionary) at: 'items'
+			   ('per_page' -> 50) } asDictionary) at: 'items'
 ]
 
 { #category : 'requesting' }
-MiGithubRepository >> searchRepositoriesNamed: aNamePart organization: anOrganizationPart [
+MiGithubRepository >> searchRepositoriesNamed: projectPattern organization: organizationPattern [
 	"I search Github for the repositories matching a part of a project name and/or a part of an organization name. I answer the raw items of the Github search results: dictionaries with 'full_name', 'description', 'language', ...
 	The organization part is resolved into owner logins with a user search because the search of repositories only filters on exact owner logins (see #searchOwnerLoginsFromOrganizationPart:). If the organization part matches no owner I answer an empty result instead of searching without the organization filter."
 
-	| namePart organizationPart ownerLogins |
-	namePart := aNamePart trimBoth.
-	organizationPart := anOrganizationPart trimBoth.
-	(namePart isEmpty and: [ organizationPart isEmpty ]) ifTrue: [ ^ #(  ) ].
-	organizationPart ifEmpty: [ ^ self searchRepositoriesFromQuery: (self repositorySearchQueryFromNamePart: namePart ownerLogins: #(  )) ].
-	ownerLogins := self searchOwnerLoginsFromOrganizationPart: organizationPart.
-	ownerLogins ifEmpty: [ ^ #(  ) ].
-	^ self searchRepositoriesFromQuery: (self repositorySearchQueryFromNamePart: namePart ownerLogins: ownerLogins)
+	(projectPattern isEmpty and: [ organizationPattern isEmpty ]) ifTrue: [ ^ #(  ) ].
+
+	organizationPattern ifEmpty: [ ^ self searchRepositoriesFromQuery: (self repositorySearchQueryFromNamePart: projectPattern ownerLogins: #(  )) ].
+
+	^ (self searchOwnerLoginsFromOrganizationPart: organizationPattern)
+		  ifEmpty: [ #(  ) ]
+		  ifNotEmpty: [ :ownerLogins | self searchRepositoriesFromQuery: (self repositorySearchQueryFromNamePart: projectPattern ownerLogins: ownerLogins) ]
 ]
 
 { #category : 'requesting' }

--- a/src/MooseIDE-Github-Importer/MiGithubRepository.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubRepository.class.st
@@ -1,0 +1,299 @@
+"
+I represent a Github project (an owner and a project name) and I am the access point of the Github importer to the Github API (through IceGitHubAPI).
+
+I can be created from a user input with #fromString: which accepts 'owner/project' or the URL of a repository ('https://github.com/owner/project' or 'git@github.com:owner/project.git'), or from the full name of a repository found in a search with #fromFullName:.
+
+I can also search for repositories matching a part of a project name and/or a part of an organization name with class>>searchRepositoriesNamed:organization:.
+
+I query the information of the repository, its primary language and the available versions: tags, branches, releases and pull requests (see #availableVersions).
+I also know the URL from which the sources of a version can be downloaded (see #downloadUrlForVersion:).
+
+I authenticate the requests with the credentials stored for github.com in the Iceberg credential store (see class>>pickGithubCredentialFrom:) when there are some: with a Github personal access token the rate limit goes from 60 requests per hour to 5000.
+"
+Class {
+	#name : 'MiGithubRepository',
+	#superclass : 'Object',
+	#instVars : [
+		'owner',
+		'projectName'
+	],
+	#category : 'MooseIDE-Github-Importer-Model',
+	#package : 'MooseIDE-Github-Importer',
+	#tag : 'Model'
+}
+
+{ #category : 'instance creation' }
+MiGithubRepository class >> fromFullName: aString [
+	"I create a repository from its full name on Github ('owner/project')."
+
+	^ self fromRepositoryPath: aString
+]
+
+{ #category : 'instance creation' }
+MiGithubRepository class >> fromHttpsUrl: aString [
+
+	^ self fromRepositoryPath: (aString allButFirst: 'https://github.com/' size)
+]
+
+{ #category : 'instance creation' }
+MiGithubRepository class >> fromRepositoryPath: aString [
+	"I parse the path of a repository ('owner/project' potentially followed by more path segments) into a repository. I answer nil if the path does not contain an owner and a project name."
+
+	| segments |
+	segments := (aString splitOn: $/) select: #isNotEmpty.
+	segments size < 2 ifTrue: [ ^ nil ].
+	^ self owner: segments first projectName: (segments second removeSuffix: '.git')
+]
+
+{ #category : 'instance creation' }
+MiGithubRepository class >> fromSshUrl: aString [
+
+	^ self fromRepositoryPath: (aString allButFirst: 'git@github.com:' size)
+]
+
+{ #category : 'instance creation' }
+MiGithubRepository class >> fromString: aString [
+	"I parse the input of the user, either 'owner/project' or the URL of a repository ('https://github.com/owner/project' or 'git@github.com:owner/project.git'). I answer nil if the input cannot be parsed."
+
+	| cleanedInput |
+	cleanedInput := aString trimBoth.
+	cleanedInput ifEmpty: [ ^ nil ].
+	(cleanedInput beginsWith: 'https://github.com/') ifTrue: [ ^ self fromHttpsUrl: cleanedInput ].
+	(cleanedInput beginsWith: 'git@github.com:') ifTrue: [ ^ self fromSshUrl: cleanedInput ].
+	^ self fromRepositoryPath: cleanedInput
+]
+
+{ #category : 'accessing' }
+MiGithubRepository class >> maximumOwnersInSearch [
+	"I am the number of owner logins that the resolution of the organization part of a search can keep. Github ranks the owners by relevance, an exact organization name is always resolved. It is also the page size of the user search."
+
+	^ 10
+]
+
+{ #category : 'accessing' }
+MiGithubRepository class >> maximumSearchQuerySize [
+	"I am the maximum size of the query accepted by the Github search of repositories."
+
+	^ 256
+]
+
+{ #category : 'instance creation' }
+MiGithubRepository class >> owner: ownerString projectName: projectString [
+
+	^ self new
+		  owner: ownerString;
+		  projectName: projectString;
+		  yourself
+]
+
+{ #category : 'credentials' }
+MiGithubRepository class >> pickGithubCredentialFrom: aCollectionOfCredentials [
+	"I pick the credentials stored for github.com to authenticate the requests of the Github API: a token credential if the user stored one (used as a Bearer authorization header), otherwise a plaintext credential (used as basic authentification). I answer nil if no present credential is stored for github.com so that the Github API is queried anonymously."
+
+	| githubCredentials |
+	githubCredentials := aCollectionOfCredentials select: [ :each | each host = 'github.com' and: [ each isPresent ] ].
+	^ githubCredentials
+		  detect: [ :each | each class = IceTokenCredentials ]
+		  ifNone: [
+				  githubCredentials
+					  detect: [ :each | each class = IcePlaintextCredentials ]
+					  ifNone: [ nil ] ]
+]
+
+{ #category : 'instance creation' }
+MiGithubRepository class >> searchRepositoriesNamed: aNamePart organization: anOrganizationPart [
+
+	^ self new searchRepositoriesNamed: aNamePart organization: anOrganizationPart
+]
+
+{ #category : 'accessing' }
+MiGithubRepository class >> searchResultsPageSize [
+
+	^ 50
+]
+
+{ #category : 'credentials' }
+MiGithubRepository class >> storeToken: aToken username: aUsername [
+	"I store a Github personal access token in the Iceberg credential store for github.com to authenticate the requests of the Github API. I replace the credential stored for github.com since the store keeps one credential per host. The token is also usable for the git operations of Iceberg (the username is needed in that case)."
+
+	IceCredentialStore current
+		storeCredential: (IceTokenCredentials new
+				 token: aToken;
+				 username: aUsername;
+				 host: 'github.com';
+				 yourself)
+		forHostname: 'github.com'
+]
+
+{ #category : 'credentials' }
+MiGithubRepository class >> storedGithubCredentials [
+
+	^ self pickGithubCredentialFrom: IceCredentialStore current allCredentials
+]
+
+{ #category : 'private' }
+MiGithubRepository >> api [
+
+	| githubApi |
+	githubApi := IceGitHubAPI new.
+	self class storedGithubCredentials ifNotNil: [ :credentials | githubApi credentials: credentials ].
+	^ githubApi
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> availableVersions [
+	"I answer all the versions of the project that can be downloaded and imported: tags, branches, releases and pull requests."
+
+	^ self tags , self branches , self releases , self pullRequests
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> branches [
+
+	^ (self get: 'repos/' , self repositoryPath , '/branches') collect: [ :each | MiGithubVersion branchNamed: (each at: 'name') ]
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> downloadUrlForVersion: aVersion [
+	"I answer the URL of the tarball of the sources of aVersion."
+
+	^ 'https://codeload.github.com/' , self repositoryPath , '/tar.gz/' , aVersion downloadRef
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> get: aPath [
+	"I query the Github API (anonymous for now). Subclasses can override me for tests."
+
+	^ self api get: aPath
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> get: aPath parameters: aDictionary [
+	"I query the Github API with parameters, URL-encoding the parameter values because IceGitHubAPI does not encode them. Subclasses can override me for tests."
+
+	| encodedParameters |
+	encodedParameters := String streamContents: [ :stream |
+			                     aDictionary associations
+				                     do: [ :association |
+						                     stream
+							                     << association key;
+							                     << '=';
+							                     << association value asString urlEncoded ]
+				                     separatedBy: [ stream << '&' ] ].
+	^ self get: aPath , '?' , encodedParameters
+]
+
+{ #category : 'accessing' }
+MiGithubRepository >> owner [
+
+	^ owner
+]
+
+{ #category : 'accessing' }
+MiGithubRepository >> owner: anObject [
+
+	owner := anObject
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> primaryLanguage [
+	"I answer the primary language of the project as given by the Github API, or nil if the Github API does not know it."
+
+	^ self repositoryInformation at: 'language'
+]
+
+{ #category : 'accessing' }
+MiGithubRepository >> projectName [
+
+	^ projectName
+]
+
+{ #category : 'accessing' }
+MiGithubRepository >> projectName: anObject [
+
+	projectName := anObject
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> pullRequests [
+	"I only list the open pull requests for now."
+
+	^ (self get: 'repos/' , self repositoryPath , '/pulls') collect: [ :each | MiGithubVersion pullRequestNumber: (each at: 'number') title: (each at: 'title') ]
+]
+
+{ #category : 'private' }
+MiGithubRepository >> queryTermsFromNamePart: aNamePart ownerLogins: aCollectionOfLogins [
+
+	| terms |
+	terms := OrderedCollection new.
+	aNamePart ifNotEmpty: [ terms add: aNamePart , ' in:name' ].
+	aCollectionOfLogins do: [ :aLogin | terms add: 'user:' , aLogin ].
+	^ terms
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> releases [
+
+	^ (self get: 'repos/' , self repositoryPath , '/releases') collect: [ :each | MiGithubVersion releaseNamed: (each at: 'tag_name') ]
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> repositoryInformation [
+
+	^ self get: 'repos/' , self repositoryPath
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> repositoryPath [
+
+	^ owner , '/' , projectName
+]
+
+{ #category : 'private' }
+MiGithubRepository >> repositorySearchQueryFromNamePart: aNamePart ownerLogins: aCollectionOfLogins [
+	"I build the query of the Github repository search: the project name part must match the repository name and each owner login is an exact owner filter. Github limits the size of a query, so I drop the last owner logins while the query is too long."
+
+	| keptLogins |
+	keptLogins := aCollectionOfLogins.
+	[ keptLogins isNotEmpty and: [ ((self queryTermsFromNamePart: aNamePart ownerLogins: keptLogins) joinUsing: ' ') size > self class maximumSearchQuerySize ] ]
+		whileTrue: [ keptLogins := keptLogins allButLast ].
+	^ (self queryTermsFromNamePart: aNamePart ownerLogins: keptLogins) joinUsing: ' '
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> searchOwnerLoginsFromOrganizationPart: anOrganizationPart [
+	"I resolve the organization part of the search into owner logins with the Github user search. I answer at most the logins of the first owners matched by Github, ranked by relevance, so an exact organization name is always resolved. I can answer an empty collection if no owner matches."
+
+	^ ((self get: 'search/users' parameters: {
+			    ('q' -> (anOrganizationPart , ' in:login')).
+			    ('per_page' -> self class maximumOwnersInSearch) } asDictionary) at: 'items') collect: [ :each | each at: 'login' ]
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> searchRepositoriesFromQuery: aQuery [
+
+	^ (self get: 'search/repositories' parameters: {
+			   ('q' -> aQuery).
+			   ('per_page' -> self class searchResultsPageSize) } asDictionary) at: 'items'
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> searchRepositoriesNamed: aNamePart organization: anOrganizationPart [
+	"I search Github for the repositories matching a part of a project name and/or a part of an organization name. I answer the raw items of the Github search results: dictionaries with 'full_name', 'description', 'language', ...
+	The organization part is resolved into owner logins with a user search because the search of repositories only filters on exact owner logins (see #searchOwnerLoginsFromOrganizationPart:). If the organization part matches no owner I answer an empty result instead of searching without the organization filter."
+
+	| namePart organizationPart ownerLogins |
+	namePart := aNamePart trimBoth.
+	organizationPart := anOrganizationPart trimBoth.
+	(namePart isEmpty and: [ organizationPart isEmpty ]) ifTrue: [ ^ #(  ) ].
+	organizationPart ifEmpty: [ ^ self searchRepositoriesFromQuery: (self repositorySearchQueryFromNamePart: namePart ownerLogins: #(  )) ].
+	ownerLogins := self searchOwnerLoginsFromOrganizationPart: organizationPart.
+	ownerLogins ifEmpty: [ ^ #(  ) ].
+	^ self searchRepositoriesFromQuery: (self repositorySearchQueryFromNamePart: namePart ownerLogins: ownerLogins)
+]
+
+{ #category : 'requesting' }
+MiGithubRepository >> tags [
+
+	^ (self get: 'repos/' , self repositoryPath , '/tags') collect: [ :each | MiGithubVersion tagNamed: (each at: 'name') ]
+]

--- a/src/MooseIDE-Github-Importer/MiGithubTargetSelectionPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubTargetSelectionPresenter.class.st
@@ -1,5 +1,5 @@
 "
-I am the bottom panel of the Github importer window (see MiGithubImportPresenter): I display the versions (tags, branches, releases and pull requests) of the Github repository selected by the user (see MiGithubRepository) and I let the user select one or more of them with checkboxes to download their sources and import them as models (see MiGithubImporter).
+I am the bottom panel of the Github importer window (see MiGithubImportPresenter): I display the versions (tags, branches, releases and pull requests) of the Github repository selected by the user (see MiGithubRepository) and I let the user select one or more of them with checkboxes. The import itself is triggered by MiGithubImportPresenter which reads my #selectedVersions.
 
 Setting a new list of versions with #versions: resets the checked versions since they belong to the previously selected project.
 "
@@ -8,9 +8,7 @@ Class {
 	#superclass : 'SpPresenter',
 	#instVars : [
 		'repository',
-		'versions',
 		'versionsTable',
-		'importButton',
 		'selectedVersions'
 	],
 	#category : 'MooseIDE-Github-Importer-UI',
@@ -31,20 +29,7 @@ MiGithubTargetSelectionPresenter >> defaultLayout [
 
 	^ SpBoxLayout newTopToBottom
 		  add: versionsTable;
-		  add: importButton expand: false;
 		  yourself
-]
-
-{ #category : 'action' }
-MiGithubTargetSelectionPresenter >> importSelectedVersions [
-
-	selectedVersions ifEmpty: [
-			self alert: 'Select at least one version to import.'.
-			^ self ].
-
-	[ MiGithubImporter downloadAndImport: selectedVersions copy from: repository ]
-		on: Error
-		do: [ :error | self alert: 'Import failed: ' , error messageText ]
 ]
 
 { #category : 'initialization' }
@@ -73,12 +58,7 @@ MiGithubTargetSelectionPresenter >> initializePresenters [
 				                  yourself);
 		                 addColumn: (SpStringTableColumn title: 'Name' evaluated: #displayName);
 		                 items: OrderedCollection new;
-		                 yourself.
-	importButton := self newButton
-		                label: 'Download and import';
-		                icon: (self iconNamed: #smallImport);
-		                action: [ self importSelectedVersions ];
-		                yourself
+		                 yourself
 ]
 
 { #category : 'accessing' }
@@ -95,6 +75,7 @@ MiGithubTargetSelectionPresenter >> repository: anObject [
 
 { #category : 'accessing' }
 MiGithubTargetSelectionPresenter >> selectedVersions [
+
 	^ selectedVersions
 ]
 

--- a/src/MooseIDE-Github-Importer/MiGithubTargetSelectionPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubTargetSelectionPresenter.class.st
@@ -18,6 +18,14 @@ Class {
 	#tag : 'UI'
 }
 
+{ #category : 'action' }
+MiGithubTargetSelectionPresenter >> clearVersions [
+
+	self
+		repository: nil;
+		versions: #(  )
+]
+
 { #category : 'layout' }
 MiGithubTargetSelectionPresenter >> defaultLayout [
 

--- a/src/MooseIDE-Github-Importer/MiGithubTargetSelectionPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubTargetSelectionPresenter.class.st
@@ -1,0 +1,106 @@
+"
+I am the bottom panel of the Github importer window (see MiGithubImportPresenter): I display the versions (tags, branches, releases and pull requests) of the Github repository selected by the user (see MiGithubRepository) and I let the user select one or more of them with checkboxes to download their sources and import them as models (see MiGithubImporter).
+
+Setting a new list of versions with #versions: resets the checked versions since they belong to the previously selected project.
+"
+Class {
+	#name : 'MiGithubTargetSelectionPresenter',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'repository',
+		'versions',
+		'versionsTable',
+		'importButton',
+		'selectedVersions'
+	],
+	#category : 'MooseIDE-Github-Importer-UI',
+	#package : 'MooseIDE-Github-Importer',
+	#tag : 'UI'
+}
+
+{ #category : 'layout' }
+MiGithubTargetSelectionPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: versionsTable;
+		  add: importButton expand: false;
+		  yourself
+]
+
+{ #category : 'action' }
+MiGithubTargetSelectionPresenter >> importSelectedVersions [
+
+	selectedVersions ifEmpty: [
+			UIManager default alert: 'Select at least one version to import.'.
+			^ self ].
+	[
+		[ MiGithubImporter downloadAndImport: selectedVersions copy from: repository ]
+			on: Error
+			do: [ :error | UIManager default alert: 'Import failed: ' , error messageText ] ] forkAt: Processor userBackgroundPriority
+]
+
+{ #category : 'initialization' }
+MiGithubTargetSelectionPresenter >> initializePresenters [
+
+	super initializePresenters.
+	versions := OrderedCollection new.
+	selectedVersions := OrderedCollection new.
+	versionsTable := self newTable
+		                 addColumn: ((SpCheckBoxTableColumn evaluated: [ :aVersion | selectedVersions includes: aVersion ])
+				                  onActivation: [ :aVersion | selectedVersions add: aVersion ];
+				                  onDeactivation: [ :aVersion | selectedVersions remove: aVersion ];
+				                  width: 20);
+		                 addColumn: (SpImageTableColumn new
+				                  evaluated: [ :aVersion | self iconNamed: aVersion iconName ];
+				                  beNotExpandable;
+				                  width: 20;
+				                  yourself);
+		                 addColumn: ((SpStringTableColumn title: 'Kind' evaluated: [ :aVersion | aVersion kind asString ])
+				                  width: 100;
+				                  yourself);
+		                 addColumn: (SpStringTableColumn title: 'Name' evaluated: #displayName);
+		                 items: versions;
+		                 yourself.
+	importButton := self newButton
+		                label: 'Download and import';
+		                icon: (self iconNamed: #smallImport);
+		                action: [ self importSelectedVersions ];
+		                yourself
+]
+
+{ #category : 'accessing' }
+MiGithubTargetSelectionPresenter >> repository [
+
+	^ repository
+]
+
+{ #category : 'accessing' }
+MiGithubTargetSelectionPresenter >> repository: anObject [
+
+	repository := anObject
+]
+
+{ #category : 'accessing' }
+MiGithubTargetSelectionPresenter >> selectedVersions [
+	^ selectedVersions
+]
+
+{ #category : 'accessing' }
+MiGithubTargetSelectionPresenter >> versions [
+
+	^ versions
+]
+
+{ #category : 'accessing' }
+MiGithubTargetSelectionPresenter >> versions: aCollection [
+
+	versions := aCollection.
+	"The checked versions belong to the previously selected project, I reset them."
+	selectedVersions := OrderedCollection new.
+	versionsTable ifNotNil: [ versionsTable items: versions ]
+]
+
+{ #category : 'accessing' }
+MiGithubTargetSelectionPresenter >> versionsTable [
+	^ versionsTable
+]

--- a/src/MooseIDE-Github-Importer/MiGithubTargetSelectionPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubTargetSelectionPresenter.class.st
@@ -39,20 +39,25 @@ MiGithubTargetSelectionPresenter >> defaultLayout [
 MiGithubTargetSelectionPresenter >> importSelectedVersions [
 
 	selectedVersions ifEmpty: [
-			UIManager default alert: 'Select at least one version to import.'.
+			self alert: 'Select at least one version to import.'.
 			^ self ].
-	[
-		[ MiGithubImporter downloadAndImport: selectedVersions copy from: repository ]
-			on: Error
-			do: [ :error | UIManager default alert: 'Import failed: ' , error messageText ] ] forkAt: Processor userBackgroundPriority
+
+	[ MiGithubImporter downloadAndImport: selectedVersions copy from: repository ]
+		on: Error
+		do: [ :error | self alert: 'Import failed: ' , error messageText ]
+]
+
+{ #category : 'initialization' }
+MiGithubTargetSelectionPresenter >> initialize [
+
+	super initialize.
+	selectedVersions := OrderedCollection new
 ]
 
 { #category : 'initialization' }
 MiGithubTargetSelectionPresenter >> initializePresenters [
 
 	super initializePresenters.
-	versions := OrderedCollection new.
-	selectedVersions := OrderedCollection new.
 	versionsTable := self newTable
 		                 addColumn: ((SpCheckBoxTableColumn evaluated: [ :aVersion | selectedVersions includes: aVersion ])
 				                  onActivation: [ :aVersion | selectedVersions add: aVersion ];
@@ -67,7 +72,7 @@ MiGithubTargetSelectionPresenter >> initializePresenters [
 				                  width: 100;
 				                  yourself);
 		                 addColumn: (SpStringTableColumn title: 'Name' evaluated: #displayName);
-		                 items: versions;
+		                 items: OrderedCollection new;
 		                 yourself.
 	importButton := self newButton
 		                label: 'Download and import';
@@ -96,16 +101,14 @@ MiGithubTargetSelectionPresenter >> selectedVersions [
 { #category : 'accessing' }
 MiGithubTargetSelectionPresenter >> versions [
 
-	^ versions
+	^ versionsTable items
 ]
 
 { #category : 'accessing' }
 MiGithubTargetSelectionPresenter >> versions: aCollection [
 
-	versions := aCollection.
-	"The checked versions belong to the previously selected project, I reset them."
-	selectedVersions := OrderedCollection new.
-	versionsTable ifNotNil: [ versionsTable items: versions ]
+	versionsTable ifNotNil: [ versionsTable items: aCollection ].
+	selectedVersions := OrderedCollection new
 ]
 
 { #category : 'accessing' }

--- a/src/MooseIDE-Github-Importer/MiGithubTokenPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubTokenPresenter.class.st
@@ -1,0 +1,100 @@
+"
+I ask the user for a Github personal access token (see https://github.com/settings/tokens) and I store it in the Iceberg credential store for github.com to authenticate the requests of the Github importer (see MiGithubRepository), raising the rate limit from 60 to 5000 requests per hour.
+
+I replace the credential stored for github.com since the Iceberg credential store keeps one credential per host. The token also serves the git operations of Iceberg, hence the username.
+"
+Class {
+	#name : 'MiGithubTokenPresenter',
+	#superclass : 'SpPresenter',
+	#instVars : [
+		'usernameInput',
+		'tokenInput'
+	],
+	#category : 'MooseIDE-Github-Importer-UI',
+	#package : 'MooseIDE-Github-Importer',
+	#tag : 'UI'
+}
+
+{ #category : 'opening' }
+MiGithubTokenPresenter class >> open [
+
+	<script>
+	^ self new
+		  openDialog;
+		  yourself
+]
+
+{ #category : 'layout' }
+MiGithubTokenPresenter >> defaultLayout [
+
+	^ SpBoxLayout newTopToBottom
+		  add: (SpBoxLayout newLeftToRight
+				   add: 'Username: ' expand: false;
+				   add: usernameInput;
+				   yourself)
+		  expand: false;
+		  add: (SpBoxLayout newLeftToRight
+				   add: 'Token: ' expand: false;
+				   add: tokenInput;
+				   yourself)
+		  expand: false;
+		  yourself
+]
+
+{ #category : 'private' }
+MiGithubTokenPresenter >> fillFromStoredToken [
+	"I prefill the fields with the stored token credential if the user stored one, to let the user edit it."
+
+	self storedToken ifNotNil: [ :tokenCredential |
+			usernameInput text: tokenCredential username.
+			tokenInput text: tokenCredential token ]
+]
+
+{ #category : 'initialization' }
+MiGithubTokenPresenter >> initializeDialogWindow: aDialog [
+
+	aDialog
+		addButton: 'Cancel' do: [ :dialog | dialog close ];
+		addButton: 'Save' do: [ :dialog |
+				self storeEnteredToken.
+				dialog close ]
+]
+
+{ #category : 'initialization' }
+MiGithubTokenPresenter >> initializePresenters [
+
+	super initializePresenters.
+	usernameInput := self newTextInput
+		                 autoAccept: true;
+		                 yourself.
+	tokenInput := self newTextInput
+		              autoAccept: true;
+		              yourself.
+	self fillFromStoredToken
+]
+
+{ #category : 'initialization' }
+MiGithubTokenPresenter >> initializeWindow: aWindowPresenter [
+
+	super initializeWindow: aWindowPresenter.
+	aWindowPresenter title: 'Github token'.
+	aWindowPresenter initialExtent: 400 @ 150
+]
+
+{ #category : 'action' }
+MiGithubTokenPresenter >> storeEnteredToken [
+
+	tokenInput text trimBoth ifEmpty: [
+			UIManager default alert: 'The token cannot be empty.'.
+			^ self ].
+	MiGithubRepository storeToken: tokenInput text trimBoth username: usernameInput text trimBoth
+]
+
+{ #category : 'private' }
+MiGithubTokenPresenter >> storedToken [
+
+	| storedCredentials |
+	storedCredentials := MiGithubRepository storedGithubCredentials.
+	(storedCredentials isNotNil and: [ storedCredentials class = IceTokenCredentials ]) ifTrue: [ ^ storedCredentials ].
+	^ nil
+]

--- a/src/MooseIDE-Github-Importer/MiGithubTokenPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubTokenPresenter.class.st
@@ -19,9 +19,7 @@ Class {
 MiGithubTokenPresenter class >> open [
 
 	<script>
-	^ self new
-		  openDialog;
-		  yourself
+	^ self new openDialog
 ]
 
 { #category : 'layout' }
@@ -85,8 +83,9 @@ MiGithubTokenPresenter >> initializeWindow: aWindowPresenter [
 MiGithubTokenPresenter >> storeEnteredToken [
 
 	tokenInput text trimBoth ifEmpty: [
-			UIManager default alert: 'The token cannot be empty.'.
+			self alert: 'The token cannot be empty.'.
 			^ self ].
+
 	MiGithubRepository storeToken: tokenInput text trimBoth username: usernameInput text trimBoth
 ]
 

--- a/src/MooseIDE-Github-Importer/MiGithubTokenPresenter.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubTokenPresenter.class.st
@@ -86,7 +86,13 @@ MiGithubTokenPresenter >> storeEnteredToken [
 			self alert: 'The token cannot be empty.'.
 			^ self ].
 
-	MiGithubRepository storeToken: tokenInput text trimBoth username: usernameInput text trimBoth
+	IceCredentialStore current
+		storeCredential: (IceTokenCredentials new
+				 token: tokenInput text trimBoth;
+				 username: usernameInput text trimBoth;
+				 host: 'github.com';
+				 yourself)
+		forHostname: 'github.com'
 ]
 
 { #category : 'private' }

--- a/src/MooseIDE-Github-Importer/MiGithubVersion.class.st
+++ b/src/MooseIDE-Github-Importer/MiGithubVersion.class.st
@@ -1,0 +1,126 @@
+"
+I represent a downloadable version of a Github project: a tag, the head of a branch, a release or the head of a pull request.
+
+I know:
+- my kind (#tag, #branch, #release or #pullRequest)
+- a display name to show in the UI
+- the ref used to download my sources from Github (see MiGithubRepository>>downloadUrlForVersion:)
+
+I also provide the name of the folder in which my sources are downloaded, relative to the project folder (see MiGithubImporter).
+"
+Class {
+	#name : 'MiGithubVersion',
+	#superclass : 'Object',
+	#instVars : [
+		'kind',
+		'displayName',
+		'downloadRef'
+	],
+	#category : 'MooseIDE-Github-Importer-Model',
+	#package : 'MooseIDE-Github-Importer',
+	#tag : 'Model'
+}
+
+{ #category : 'instance creation' }
+MiGithubVersion class >> branchNamed: aString [
+
+	^ self kind: #branch displayName: aString downloadRef: 'refs/heads/' , aString
+]
+
+{ #category : 'instance creation' }
+MiGithubVersion class >> kind: aKind displayName: aDisplayName downloadRef: aDownloadRef [
+
+	^ self new
+		  kind: aKind;
+		  displayName: aDisplayName;
+		  downloadRef: aDownloadRef;
+		  yourself
+]
+
+{ #category : 'instance creation' }
+MiGithubVersion class >> pullRequestNumber: aNumber title: aString [
+
+	^ self
+		  kind: #pullRequest
+		  displayName: ('Pull request #{1}: {2}' format: {
+					   aNumber.
+					   aString })
+		  downloadRef: ('refs/pull/{1}/head' format: { aNumber })
+]
+
+{ #category : 'instance creation' }
+MiGithubVersion class >> releaseNamed: aString [
+
+	^ self kind: #release displayName: aString downloadRef: 'refs/tags/' , aString
+]
+
+{ #category : 'instance creation' }
+MiGithubVersion class >> tagNamed: aString [
+
+	^ self kind: #tag displayName: aString downloadRef: 'refs/tags/' , aString
+]
+
+{ #category : 'accessing' }
+MiGithubVersion >> displayName [
+
+	^ displayName
+]
+
+{ #category : 'accessing' }
+MiGithubVersion >> displayName: anObject [
+
+	displayName := anObject
+]
+
+{ #category : 'accessing' }
+MiGithubVersion >> downloadRef [
+
+	^ downloadRef
+]
+
+{ #category : 'accessing' }
+MiGithubVersion >> downloadRef: anObject [
+
+	downloadRef := anObject
+]
+
+{ #category : 'accessing' }
+MiGithubVersion >> folderName [
+	"I am the name of the folder in which my sources are downloaded, relative to the project folder (see MiGithubImporter). For pull requests I use the number of the pull request and for tags, branches and releases I replace the potential '/' of the name to not create nested folders."
+
+	kind = #pullRequest ifTrue: [ ^ 'PR-' , ((downloadRef allButFirst: 'refs/pull/' size) copyUpTo: $/) ].
+	^ displayName copyReplaceAll: '/' with: '-'
+]
+
+{ #category : 'accessing' }
+MiGithubVersion >> iconName [
+	"I am the name of the icon to display next to my kind in the UI, as in the Software Heritage importer. Tags and releases share the same icon."
+
+	kind = #branch ifTrue: [ ^ #branch ].
+	kind = #pullRequest ifTrue: [ ^ #merge ].
+	^ #glamorousBookmark
+]
+
+{ #category : 'accessing' }
+MiGithubVersion >> kind [
+
+	^ kind
+]
+
+{ #category : 'accessing' }
+MiGithubVersion >> kind: anObject [
+
+	kind := anObject
+]
+
+{ #category : 'printing' }
+MiGithubVersion >> printOn: aStream [
+
+	super printOn: aStream.
+	aStream
+		<< ' (';
+		<< kind asString;
+		<< ': ';
+		<< displayName;
+		<< ')'
+]

--- a/src/MooseIDE-Github-Importer/MiImportFromGithubCommand.class.st
+++ b/src/MooseIDE-Github-Importer/MiImportFromGithubCommand.class.st
@@ -1,0 +1,40 @@
+"
+I am the command to open the Github importer UI (see MiGithubImportPresenter). I am displayed in the ""Import"" toolbar of the models browser with the other import commands.
+"
+Class {
+	#name : 'MiImportFromGithubCommand',
+	#superclass : 'MiImportCommand',
+	#category : 'MooseIDE-Github-Importer-UI',
+	#package : 'MooseIDE-Github-Importer',
+	#tag : 'UI'
+}
+
+{ #category : 'accessing' }
+MiImportFromGithubCommand class >> defaultDescription [
+
+	^ 'Download the sources of versions of a Github project and import them as models (Java only for now)'
+]
+
+{ #category : 'accessing' }
+MiImportFromGithubCommand class >> defaultIcon [
+
+	^ Smalltalk ui icons iconNamed: self defaultIconName
+]
+
+{ #category : 'accessing' }
+MiImportFromGithubCommand class >> defaultIconName [
+
+	^ #github
+]
+
+{ #category : 'accessing' }
+MiImportFromGithubCommand class >> defaultName [
+
+	^ 'Import from Github'
+]
+
+{ #category : 'accessing' }
+MiImportFromGithubCommand class >> importForm [
+
+	^ MiGithubImportPresenter
+]

--- a/src/MooseIDE-Github-Importer/package.st
+++ b/src/MooseIDE-Github-Importer/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'MooseIDE-Github-Importer' }

--- a/src/MooseIDE-Meta/MiMooseModelsWrapper.class.st
+++ b/src/MooseIDE-Meta/MiMooseModelsWrapper.class.st
@@ -42,6 +42,11 @@ MiMooseModelsWrapper >> installWithCache: aBoolean [
 ]
 
 { #category : 'accessing' }
+MiMooseModelsWrapper >> models [
+	^ models
+]
+
+{ #category : 'accessing' }
 MiMooseModelsWrapper >> models: aCollection [
 
 	models := aCollection


### PR DESCRIPTION
This PR propose to add a github importer for Moose.

This is a first version with limitations.
- We can search projects on github based on their names and owner. Later we could add more filters
- For now, it works only for Java, later I'd like to add support for other languages
- For now it only uses the latest version of VVJ and does not let the user provide additional import info such as dependencies path or jdk version

In the future I'd like to add pragmas to each Famix importer to make them discoverable and we could delegate the request of additional info to the importers depending on the language.

Also we can provide a github token to lift the API limit rate

But it will be for another time. 

<img width="608" height="707" alt="image" src="https://github.com/user-attachments/assets/e686fae4-6ec0-4710-9c8f-7c327b5dcb0a" />

